### PR TITLE
fix: Add token permissions to fix trusted publishing

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -22,6 +22,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 env:
   SDK_PATH: Sdk/MParticle.Maui.Sdk

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   SDK_PATH: Sdk/MParticle.Maui.Sdk


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Previous run failed with `Missing GitHub OIDC request environment variables.` which I believe is caused by token permissions 

## What Has Changed

- Add token permissions to fix trusted publishing

## Screenshots/Video

- N/A

## Checklist

- [X] I have performed a self-review of my own code.

## Additional Notes

- N/A

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes N/A
