### PR TITLE
fix: Use Nugettest token URL

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -50,6 +50,8 @@ jobs:
         id: login
         with:
           user: rokt
+          token-service-url: https://int.nugettest.org/api/v2/token
+          audience: https://int.nugettest.org
 
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Failed due to mismatch of Nuget vs Nugettest
- Found an example [here](https://github.com/lballabio/quantlib-wheels/blob/3d3bf84deeb140d626e7b2be34d65080e65a38b8/.github/workflows/dotnet.yml#L232C24-L234C44)

## What Has Changed

- Draft release workflow

## Screenshots/Video

- N/A

## Checklist

- [X] I have performed a self-review of my own code.

## Additional Notes

- N/A

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes N/A
