### PR TITLE
fix: Correct Rokt Kit csproj filename

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -28,7 +28,7 @@ env:
   SDK_PATH: Sdk/MParticle.Maui.Sdk
   SDK_PROJECT: MParticle.Maui.Sdk
   ROKT_KIT_PATH: Kits/rokt/Sdk/MParticle.Maui.Rokt
-  ROKT_KIT_PROJECT: MParticle.Maui.Kits.Rokt
+  ROKT_KIT_PROJECT: mParticle.Maui.Kits.Rokt
 
 jobs:
   publish-draft-release:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ env:
   SDK_PATH: Sdk/MParticle.Maui.Sdk
   SDK_PROJECT: MParticle.Maui.Sdk
   ROKT_KIT_PATH: Kits/rokt/Sdk/MParticle.Maui.Rokt
-  ROKT_KIT_PROJECT: MParticle.Maui.Kits.Rokt
+  ROKT_KIT_PROJECT: mParticle.Maui.Kits.Rokt
 
 jobs:
   trunk-check:

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -15,7 +15,7 @@ env:
   SDK_PATH: Sdk/MParticle.Maui.Sdk
   SDK_PROJECT: MParticle.Maui.Sdk
   ROKT_KIT_PATH: Kits/rokt/Sdk/MParticle.Maui.Rokt
-  ROKT_KIT_PROJECT: MParticle.Maui.Kits.Rokt
+  ROKT_KIT_PROJECT: mParticle.Maui.Kits.Rokt
 
 jobs:
   setup-and-version:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected filename for Rokt kit CSPROJ file from `MParticle.Maui.Kits.Rokt` to `mParticle.Maui.Kits.Rokt`
+
 ## [4.0.0] - 2025-11-11
 
 ### Changed


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- When performing the [last release](https://github.com/mParticle/mparticle-maui-sdk/actions/runs/19269506551/job/55093757990) the command `git status` gets run which is case sensitive
- The draft release action was trying to upload `MParticle.Maui.Kits.Rokt.csproj` however it wouldn't be returned by git status as it's actually called `mParticle.Maui.Kits.Rokt.csproj`

## What Has Changed

- Corrected filename

## Screenshots/Video

- N/A

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have made corresponding changes to the documentation.
- [X] I have tested this locally.

## Additional Notes

- N/A

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes N/A
