### PR TITLE
fix: Create pull request with token

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -150,9 +150,20 @@ jobs:
           name: ${{ env.ROKT_KIT_PROJECT }}.${{ steps.full-version.outputs.full-version-with-suffix }}.nupkg
           path: ${{ env.ROKT_KIT_PATH }}/bin/Release/${{ env.ROKT_KIT_PROJECT }}.${{ steps.full-version.outputs.full-version-with-suffix }}.nupkg
 
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ secrets.SDK_RELEASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.SDK_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            mparticle-maui-sdk
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: Create ${{ steps.bump-version.outputs.new_version }}
           branch: release/${{ steps.bump-version.outputs.new_version }}
           title: Prepare release ${{ steps.bump-version.outputs.new_version }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- Pull requests without using a token do not run required PR tasks
- This PR requests an external token so they can successfully run

## What Has Changed

- Create draft release workflow

## Screenshots/Video

<img width="667" height="88" alt="Screenshot 2025-11-17 at 12 57 16 PM" src="https://github.com/user-attachments/assets/449e52a1-a9f4-4b08-812e-98efea7b22f8" />

## Checklist

- [X] I have performed a self-review of my own code.

## Additional Notes

- N/A

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes N/A
