### PR TITLE
fix: Duplicate package version

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -90,7 +90,7 @@ jobs:
           if [ -n "${{ github.event.inputs.version-suffix }}" ]; then
             version_suffix="${{ github.event.inputs.version-suffix }}"
           else
-            version_suffix="-alpha.${{ github.run_attempt }}"
+            version_suffix="-alpha.${{ github.run_number }}"
           fi
           echo "version-suffix=$version_suffix" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

- When attempting to publish we are using the run attempt instead of the run number which results in `A package with ID 'mParticle.MAUI' and version '4.0.1-alpha.1' already exists and cannot be modified.`

## What Has Changed

- Suffix versioning

## Screenshots/Video

<img width="1113" height="244" alt="Screenshot 2025-11-18 at 10 01 11 AM" src="https://github.com/user-attachments/assets/0713b46c-0245-41fd-a845-a77a45ecd1ce" />

## Checklist

- [X] I have performed a self-review of my own code.

## Additional Notes

- N/A

## Reference Issue (For employees only. Ignore if you are an outside contributor)

- Closes N/A
