### PR TITLE
feat: Upgrade to .NET 10 MAUI

### DIFF
--- a/Kits/rokt/global.json
+++ b/Kits/rokt/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.103",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-        <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+        <!-- <TargetFrameworks>$(TargetFrameworks);net10.0-tizen</TargetFrameworks> -->
 
         <!-- Note for MacCatalyst:
         The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.

--- a/Sdk/MParticle.Maui.Sdk/MParticle.Maui.Sdk.csproj
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.Maui.Sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
+        <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -78,22 +78,23 @@
         </AndroidLibrary>
         
         <!--mParticle SDK Dependencies-->
-        <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.9.3" />
-        <PackageReference Include="Xamarin.AndroidX.Activity.ktx" Version="1.9.3" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.4" />
-        <PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.4" />
-        <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.3" />
-        <PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.1.21" />
-        <PackageReference Include="Xamarin.KotlinX.Coroutines.Core" Version="1.9.0" />
-        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.9.0" />
+        <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.10.1.3" />
+        <PackageReference Include="Xamarin.AndroidX.Activity.ktx" Version="1.10.1.3" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.5.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.5.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.8.8.1" />
+        <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.8.1" />
+        <PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.2.0.1" />
+        <PackageReference Include="Xamarin.KotlinX.Coroutines.Core" Version="1.10.2.1" />
+        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.10.2.1" />
     </ItemGroup>
 
     <ItemGroup Condition="$(TargetFramework.Contains('android'))">

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.103",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
## Background

Upgraded SDK from .NET 8 MAUI to .NET 10 MAUI to resolve XA4212 build error with AndroidX.Navigation.Compose on .NET 10 MAUI. This ensures compatibility with the latest MAUI framework version.

## What Has Changed

- Updated target frameworks from `net8.0-ios/net8.0-android` to `net10.0-ios/net10.0-android` across all SDK and sample projects
- Updated .NET SDK version to 10.0.103 in `global.json` files
- Updated AndroidX and Kotlin dependencies to versions compatible with MAUI 10.0.20
- Updated build documentation to reflect new target framework names

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- Resolved version conflicts with AndroidX dependencies (Fragment, Activity, Lifecycle, Collection, Kotlin libraries)
- All projects now consistently target .NET 10 MAUI frameworks