### PR TITLE
feat: Upgrade to .NET 10 MAUI

### DIFF
--- a/.cursor/rules/build-and-test.mdc
+++ b/.cursor/rules/build-and-test.mdc
@@ -24,17 +24,17 @@ dotnet build SampleApp/SampleApp.csproj
 cd SampleApp
 
 # To run android
-dotnet build -t:Run -f net8.0-android
+dotnet build -t:Run -f net10.0-android
 
 # To run iOS
-dotnet build -t:Run -f net8.0-ios
+dotnet build -t:Run -f net10.0-ios
 
 # To run iOS on a specific device you can find the UDID with
 xcrun simctl list devices | grep "Booted"
 
 # This UDID can then be used in the following command
 
-dotnet build -t:Run -f net8.0-ios -p:_DeviceName=:v2:udid=MY_SPECIFIC_UDID
+dotnet build -t:Run -f net10.0-ios -p:_DeviceName=:v2:udid=MY_SPECIFIC_UDID
 ```
 
 ## Linting and Formatting with Trunk

--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -57,12 +57,12 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.0.103
 
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 16.4
+          xcode-version: 26.2
 
       - name: Install .NET MAUI
         run: dotnet workload install maui
@@ -108,6 +108,17 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
+      - name: Resolve SPM dependencies for Xcode project
+        run: |
+          cd ${{ env.SDK_PATH }}/macios/native/mParticleBinding
+          xcodebuild -resolvePackageDependencies -project mParticleBinding.xcodeproj -scheme mParticleBinding
+
+      - name: Build Xcode project to generate framework
+        run: |
+          cd ${{ env.SDK_PATH }}/macios/native/mParticleBinding
+          xcodebuild -project mParticleBinding.xcodeproj -scheme mParticleBinding -configuration Release -sdk iphoneos build
+          xcodebuild -project mParticleBinding.xcodeproj -scheme mParticleBinding -configuration Release -sdk iphonesimulator build
+
       - name: Build SDK
         run: dotnet build ${{ env.SDK_PATH }}/${{ env.SDK_PROJECT }}.csproj -c Release -p:Version=${{ steps.full-version.outputs.full-version-with-suffix }}
 
@@ -116,6 +127,17 @@ jobs:
 
       - name: Publish to NuGet Test Gallery
         run: dotnet nuget push ${{ env.SDK_PATH }}/bin/Release/mParticle.MAUI.${{ steps.full-version.outputs.full-version-with-suffix }}.nupkg --source https://apiint.nugettest.org/v3/index.json --api-key ${{steps.login.outputs.NUGET_API_KEY}}
+
+      - name: Resolve SPM dependencies for Rokt Kit iOS binding
+        run: |
+          cd ${{ env.ROKT_KIT_PATH }}/macios/native/mParticleRoktBinding
+          xcodebuild -resolvePackageDependencies -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding
+
+      - name: Build Xcode project for Rokt Kit iOS
+        run: |
+          cd ${{ env.ROKT_KIT_PATH }}/macios/native/mParticleRoktBinding
+          xcodebuild -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding -configuration Release -sdk iphoneos build
+          xcodebuild -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding -configuration Release -sdk iphonesimulator build
 
       - name: Build Rokt Kit
         run: dotnet build ${{ env.ROKT_KIT_PATH }}/${{ env.ROKT_KIT_PROJECT }}.csproj -c Release -p:Version=${{ steps.full-version.outputs.full-version-with-suffix }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.0.103
 
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 16.4
+          xcode-version: 26.2
 
       - name: Install .NET MAUI
         run: dotnet workload install maui
@@ -57,20 +57,42 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
+      - name: Resolve SPM dependencies for iOS binding
+        run: |
+          cd ${{ env.SDK_PATH }}/macios/native/mParticleBinding
+          xcodebuild -resolvePackageDependencies -project mParticleBinding.xcodeproj -scheme mParticleBinding
+
+      - name: Build Xcode project for iOS
+        run: |
+          cd ${{ env.SDK_PATH }}/macios/native/mParticleBinding
+          xcodebuild -project mParticleBinding.xcodeproj -scheme mParticleBinding -configuration Debug -sdk iphoneos build
+          xcodebuild -project mParticleBinding.xcodeproj -scheme mParticleBinding -configuration Debug -sdk iphonesimulator build
+
       - name: Build SDK
         run: dotnet build ${{ env.SDK_PATH }}/${{ env.SDK_PROJECT }}.csproj
 
       - name: Build SDK SampleApp
         run: dotnet build SampleApp/SampleApp.csproj
 
-      - name: Pack SDK
-        run: dotnet pack ${{ env.SDK_PATH }}/${{ env.SDK_PROJECT }}.csproj
+      - name: Resolve SPM dependencies for Rokt Kit iOS binding
+        run: |
+          cd ${{ env.ROKT_KIT_PATH }}/macios/native/mParticleRoktBinding
+          xcodebuild -resolvePackageDependencies -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding
+
+      - name: Build Xcode project for Rokt Kit iOS
+        run: |
+          cd ${{ env.ROKT_KIT_PATH }}/macios/native/mParticleRoktBinding
+          xcodebuild -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding -configuration Debug -sdk iphoneos build
+          xcodebuild -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding -configuration Debug -sdk iphonesimulator build
 
       - name: Build Rokt Kit
         run: dotnet build ${{ env.ROKT_KIT_PATH }}/${{ env.ROKT_KIT_PROJECT }}.csproj
 
       - name: Build Rokt Kit SampleApp
         run: dotnet build Kits/rokt/SampleApp/SampleApp.csproj
+
+      - name: Pack SDK
+        run: dotnet pack ${{ env.SDK_PATH }}/${{ env.SDK_PROJECT }}.csproj
 
       - name: Pack Rokt Kit
         run: dotnet pack ${{ env.ROKT_KIT_PATH }}/${{ env.ROKT_KIT_PROJECT }}.csproj

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -54,12 +54,12 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.0.103
 
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 16.4
+          xcode-version: 26.2
 
       - name: Install .NET MAUI
         run: dotnet workload install maui
@@ -67,14 +67,36 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
+      - name: Resolve SPM dependencies for Xcode project
+        run: |
+          cd ${{ env.SDK_PATH }}/macios/native/mParticleBinding
+          xcodebuild -resolvePackageDependencies -project mParticleBinding.xcodeproj -scheme mParticleBinding
+
+      - name: Build Xcode project to generate framework
+        run: |
+          cd ${{ env.SDK_PATH }}/macios/native/mParticleBinding
+          xcodebuild -project mParticleBinding.xcodeproj -scheme mParticleBinding -configuration Release -sdk iphoneos build
+          xcodebuild -project mParticleBinding.xcodeproj -scheme mParticleBinding -configuration Release -sdk iphonesimulator build
+
       - name: Build SDK
-        run: dotnet build ${{ env.SDK_PATH }}/${{ env.SDK_PROJECT }}.csproj -c Release
+        run: dotnet build ${{ env.SDK_PATH }}/${{ env.SDK_PROJECT }}.csproj -c Release -f net10.0-ios
 
       - name: Pack SDK
         run: dotnet pack ${{ env.SDK_PATH }}/${{ env.SDK_PROJECT }}.csproj -c Release
 
       - name: Publish SDK to NuGet Gallery
         run: dotnet nuget push ${{ env.SDK_PATH }}/bin/Release/mParticle.MAUI.${{ needs.setup-and-version.outputs.final_version }}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
+
+      - name: Resolve SPM dependencies for Rokt Kit iOS binding
+        run: |
+          cd ${{ env.ROKT_KIT_PATH }}/macios/native/mParticleRoktBinding
+          xcodebuild -resolvePackageDependencies -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding
+
+      - name: Build Xcode project for Rokt Kit iOS
+        run: |
+          cd ${{ env.ROKT_KIT_PATH }}/macios/native/mParticleRoktBinding
+          xcodebuild -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding -configuration Release -sdk iphoneos build
+          xcodebuild -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding -configuration Release -sdk iphonesimulator build
 
       - name: Build Rokt Kit
         run: dotnet build ${{ env.ROKT_KIT_PATH }}/${{ env.ROKT_KIT_PROJECT }}.csproj -c Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded target frameworks from .NET 8.0 to .NET 10.0 MAUI for all SDK and sample projects
+- Updated Android dependencies
+
+### Fixed
+
+- Resolved XA4212 build error with AndroidX.Navigation.Compose on .NET 10 MAUI
+
 ## [4.0.1] - 2025-11-18
 
 ### Fixed

--- a/Kits/rokt/SampleApp/SampleApp.csproj
+++ b/Kits/rokt/SampleApp/SampleApp.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-        <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+        <!-- <TargetFrameworks>$(TargetFrameworks);net10.0-tizen</TargetFrameworks> -->
 
         <!-- Note for MacCatalyst:
         The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
@@ -30,7 +30,7 @@
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
         <ApplicationVersion>1</ApplicationVersion>
 
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt/mParticle.Maui.Kits.Rokt.csproj
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt/mParticle.Maui.Kits.Rokt.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
+        <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -49,13 +49,9 @@
 
     <ItemGroup Condition="$(TargetFramework.Contains('ios'))">
         <ObjcBindingApiDefinition Include="macios/mParticleRoktBinding.MaciOS.Binding/ApiDefinitions.cs" />
-        <NLIXcodeProjectReference Include="macios/native/mParticleRoktBinding/mParticleRoktBinding.xcodeproj">
+        <XcodeProject Include="macios/native/mParticleRoktBinding/mParticleRoktBinding.xcodeproj">
             <SchemeName>mParticleRoktBinding</SchemeName>
-            <!-- Metadata applicable to @(NativeReference) will be used if set, otherwise the following defaults will be used:
-            <Kind>Framework</Kind>
-            <SmartLink>true</SmartLink>
-            -->
-        </NLIXcodeProjectReference>
+        </XcodeProject>
         <Folder Include="macios\native\mParticleSPM\" />
     </ItemGroup>
 
@@ -140,33 +136,35 @@
         </AndroidLibrary>
         
     <!--Rokt SDK Dependency Bindings-->
-        <PackageReference Include="Xamarin.KotlinX.Serialization.Core.Jvm" Version="1.7.3.1" />
+        <PackageReference Include="Xamarin.KotlinX.Serialization.Core.Jvm" Version="1.9.0.1" />
         <PackageReference Include="Org.Jetbrains.Kotlinx.KotlinxSerializationJsonJvm" Version="1.7.3" />
         <PackageReference Include="Square.Retrofit2" Version="2.9.0.8" />
         <PackageReference Include="Square.Retrofit2.AdapterRxJava2" Version="2.9.0.8" />
         <PackageReference Include="Square.Retrofit2.ConverterGson" Version="2.9.0.8" />
         <PackageReference Include="Xamarin.Android.ReactiveX.RxAndroid" Version="2.1.1.1" />
         
-        <PackageReference Include="Xamarin.AndroidX.Compose.Material" Version="1.7.2" />
+        <PackageReference Include="Xamarin.AndroidX.Compose.Material" Version="1.8.3.1" />
         <PackageReference Include="Xamarin.AndroidX.Compose.Material3" Version="1.3.0" />
-        <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.9.3" />
-        <PackageReference Include="Xamarin.AndroidX.Activity.ktx" Version="1.9.3" />
-        <PackageReference Include="Xamarin.AndroidX.Activity.Compose" Version="1.9.3" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Compose" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.4" />
-        <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.3" />
-        <PackageReference Include="Xamarin.AndroidX.Navigation.Compose" Version="2.8.0.1" />
+        <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.10.1.3" />
+        <PackageReference Include="Xamarin.AndroidX.Activity.ktx" Version="1.10.1.3" />
+        <PackageReference Include="Xamarin.AndroidX.Activity.Compose" Version="1.10.1.3" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Compose" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModelSavedState" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.5.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.5.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.8.8.1" />
+        <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.8.1" />
+        <PackageReference Include="Xamarin.AndroidX.Navigation.Compose" Version="2.9.2.1" />
 
-        <PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.1.21" />
+        <PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.2.0.1" />
         
     <!--Rokt SDK Dependencies Without Bindings-->
         <AndroidLibrary Include=".\android\native\MParticleRoktBinding\MParticleRoktBinding\bin\Release\$(TargetFramework)\outputs\deps\retrofit2-kotlinx-serialization-converter-0.8.0.jar">
@@ -223,11 +221,16 @@
         <None Include="**\android\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     </ItemGroup>
 
-    <!-- Copy Rokt_Widget.xcframework from SPM to resources after build and update manifest -->
-    <Target Name="CopyRoktWidgetFramework" AfterTargets="_CreateBindingResourcePackage" Condition="$(TargetFramework.Contains('ios'))">
-        <Exec Command="cp -R $(HOME)/Library/Developer/Xcode/DerivedData/mParticleRoktBinding-*/SourcePackages/artifacts/rokt-sdk-ios/Rokt_Widget/Rokt_Widget.xcframework &quot;$(OutputPath)MParticle.Maui.Kits.Rokt.resources/&quot;" />
-        <!-- Append Rokt_Widget as a NativeReference to the manifest before the closing BindingAssembly tag -->
-        <Exec Command="sed -i '' 's|&lt;/BindingAssembly&gt;|&lt;NativeReference Name=&quot;Rokt_Widget.xcframework&quot;&gt;&lt;Kind&gt;Framework&lt;/Kind&gt;&lt;SmartLink&gt;false&lt;/SmartLink&gt;&lt;/NativeReference&gt;&lt;/BindingAssembly&gt;|g' &quot;$(OutputPath)MParticle.Maui.Kits.Rokt.resources/manifest&quot;" />
+    <!-- Copy Rokt_Widget.xcframework from SPM to resources after Build -->
+    <Target Name="CopyRoktWidgetFramework" AfterTargets="Build" Condition="$(TargetFramework.Contains('ios'))">
+        <!-- Copy xcframework from DerivedData -->
+        <Exec Command="cp -R $(HOME)/Library/Developer/Xcode/DerivedData/mParticleRoktBinding-*/SourcePackages/artifacts/rokt-sdk-ios/Rokt_Widget/Rokt_Widget.xcframework &quot;$(OutputPath)MParticle.Maui.Kits.Rokt.resources/&quot;" ContinueOnError="true" />
+        <!-- Copy manifest template if xcframework was copied successfully -->
+        <Copy 
+            SourceFiles="$(MSBuildThisFileDirectory)manifest.template" 
+            DestinationFiles="$(OutputPath)MParticle.Maui.Kits.Rokt.resources/manifest"
+            Condition="Exists('$(OutputPath)MParticle.Maui.Kits.Rokt.resources/Rokt_Widget.xcframework')"
+            SkipUnchangedFiles="true" />
     </Target>
 
     <!-- Clean MParticleRoktBinding DerivedData from global Xcode cache during clean -->

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt/manifest.template
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt/manifest.template
@@ -1,0 +1,6 @@
+<BindingAssembly>
+  <NativeReference Name="Rokt_Widget.xcframework">
+    <Kind>Framework</Kind>
+    <SmartLink>false</SmartLink>
+  </NativeReference>
+</BindingAssembly>

--- a/Kits/rokt/global.json
+++ b/Kits/rokt/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.103",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-        <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+        <!-- <TargetFrameworks>$(TargetFrameworks);net10.0-tizen</TargetFrameworks> -->
 
         <!-- Note for MacCatalyst:
         The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
@@ -30,7 +30,7 @@
         <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
         <ApplicationVersion>1</ApplicationVersion>
 
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">12.2</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>

--- a/Sdk/MParticle.Maui.Sdk/MParticle.Maui.Sdk.csproj
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.Maui.Sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;net8.0-android</TargetFrameworks>
+        <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
         <UseMaui>true</UseMaui>
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -47,13 +47,9 @@
     <ItemGroup Condition="$(TargetFramework.Contains('ios'))">
         <ObjcBindingApiDefinition Include="macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs" />
         <ObjcBindingCoreSource Include="macios/mParticleBinding.MaciOS.Binding/StructsAndEnums.cs" />
-        <NLIXcodeProjectReference Include="macios/native/mParticleBinding/mParticleBinding.xcodeproj">
+        <XcodeProject Include="macios/native/mParticleBinding/mParticleBinding.xcodeproj">
             <SchemeName>mParticleBinding</SchemeName>
-            <!-- Metadata applicable to @(NativeReference) will be used if set, otherwise the following defaults will be used:
-            <Kind>Framework</Kind>
-            <SmartLink>true</SmartLink>
-            -->
-        </NLIXcodeProjectReference>
+        </XcodeProject>
         <Folder Include="macios\native\mParticleSPM\" />
     </ItemGroup>
 
@@ -78,22 +74,23 @@
         </AndroidLibrary>
         
         <!--mParticle SDK Dependencies-->
-        <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.9.3" />
-        <PackageReference Include="Xamarin.AndroidX.Activity.ktx" Version="1.9.3" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.8.6" />
-        <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.4" />
-        <PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.4" />
-        <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.3" />
-        <PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.1.21" />
-        <PackageReference Include="Xamarin.KotlinX.Coroutines.Core" Version="1.9.0" />
-        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.9.0" />
+        <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.10.1.3" />
+        <PackageReference Include="Xamarin.AndroidX.Activity.ktx" Version="1.10.1.3" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Common.Java8" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData.Core.Ktx" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Lifecycle.ViewModel.Ktx" Version="2.9.2.1" />
+        <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.5.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.5.0.3" />
+        <PackageReference Include="Xamarin.AndroidX.Fragment" Version="1.8.8.1" />
+        <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.8.1" />
+        <PackageReference Include="Xamarin.Kotlin.StdLib" Version="2.2.0.1" />
+        <PackageReference Include="Xamarin.KotlinX.Coroutines.Core" Version="1.10.2.1" />
+        <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.10.2.1" />
     </ItemGroup>
 
     <ItemGroup Condition="$(TargetFramework.Contains('android'))">
@@ -120,11 +117,16 @@
         <None Include="**\android\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     </ItemGroup>
 
-    <!-- Copy mParticle_Apple_SDK.xcframework from SPM to resources after build and update manifest -->
-    <Target Name="CopymParticleAppleSDKFramework" AfterTargets="_CreateBindingResourcePackage" Condition="$(TargetFramework.Contains('ios'))">
-        <Exec Command="cp -R $(HOME)/Library/Developer/Xcode/DerivedData/mParticleBinding-*/SourcePackages/artifacts/mparticle-apple-sdk/mParticle_Apple_SDK/mParticle_Apple_SDK.xcframework &quot;$(OutputPath)MParticle.Maui.Sdk.resources/&quot;" />
-        <!-- Append mParticle_Apple_SDK as a NativeReference to the manifest before the closing BindingAssembly tag -->
-        <Exec Command="sed -i '' 's|&lt;/BindingAssembly&gt;|&lt;NativeReference Name=&quot;mParticle_Apple_SDK.xcframework&quot;&gt;&lt;Kind&gt;Framework&lt;/Kind&gt;&lt;SmartLink&gt;false&lt;/SmartLink&gt;&lt;/NativeReference&gt;&lt;/BindingAssembly&gt;|g' &quot;$(OutputPath)MParticle.Maui.Sdk.resources/manifest&quot;" />
+    <!-- Copy mParticle_Apple_SDK.xcframework from SPM to resources after Build -->
+    <Target Name="CopymParticleAppleSDKFramework" AfterTargets="Build" Condition="$(TargetFramework.Contains('ios'))">
+        <!-- Copy xcframework from DerivedData -->
+        <Exec Command="cp -R $(HOME)/Library/Developer/Xcode/DerivedData/mParticleBinding-*/SourcePackages/artifacts/mparticle-apple-sdk/mParticle_Apple_SDK/mParticle_Apple_SDK.xcframework &quot;$(OutputPath)MParticle.Maui.Sdk.resources/&quot;" ContinueOnError="true" />
+        <!-- Copy manifest template if xcframework was copied successfully -->
+        <Copy 
+            SourceFiles="$(MSBuildThisFileDirectory)manifest.template" 
+            DestinationFiles="$(OutputPath)MParticle.Maui.Sdk.resources/manifest"
+            Condition="Exists('$(OutputPath)MParticle.Maui.Sdk.resources/mParticle_Apple_SDK.xcframework')"
+            SkipUnchangedFiles="true" />
     </Target>
 
     <!-- Clean mParticleBinding DerivedData from global Xcode cache during clean -->

--- a/Sdk/MParticle.Maui.Sdk/manifest.template
+++ b/Sdk/MParticle.Maui.Sdk/manifest.template
@@ -1,0 +1,6 @@
+<BindingAssembly>
+  <NativeReference Name="mParticle_Apple_SDK.xcframework">
+    <Kind>Framework</Kind>
+    <SmartLink>false</SmartLink>
+  </NativeReference>
+</BindingAssembly>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.103",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
## Background

Upgraded SDK from .NET 8 MAUI to .NET 10 MAUI to resolve XA4212 build error with AndroidX.Navigation.Compose on .NET 10 MAUI. This ensures compatibility with the latest MAUI framework version.

## What Has Changed

- Updated target frameworks from `net8.0-ios/net8.0-android` to `net10.0-ios/net10.0-android` across all SDK and sample projects
- Updated .NET SDK version to 10.0.103 in `global.json` files
- Updated AndroidX and Kotlin dependencies to versions compatible with MAUI 10.0.20
- Updated build documentation to reflect new target framework names

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
- Verified locally with both Android and iOS  versions of Sample App
- Resolved version conflicts with AndroidX dependencies (Fragment, Activity, Lifecycle, Collection, Kotlin libraries)
- All projects now consistently target .NET 10 MAUI frameworks