### PR TITLE
chore: update mParticle Apple SDK to 9.0 and align Rokt bindings

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.2
+          xcode-version: 26.3
 
       - name: Install .NET MAUI
         run: dotnet workload install maui

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.2
+          xcode-version: 26.3
 
       - name: Install .NET MAUI
         run: dotnet workload install maui

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.2
+          xcode-version: 26.3
 
       - name: Install .NET MAUI
         run: dotnet workload install maui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This release upgrades the iOS binding to mParticle Apple SDK 9 and contains breaking changes. See [MIGRATING.md](./MIGRATING.md) for the full 4.x → 5.0 upgrade guide.
+
+### Changed
+
+- **BREAKING**: iOS minimum deployment target raised from `11.0` to `15.0`.
+- **BREAKING**: Updated iOS SPM dependency from `mparticle-apple-sdk` 8.40.0 to 9.0.0 in both the core SDK and Rokt kit.
+- **BREAKING**: Rokt kit now depends on the renamed `mp-apple-integration-rokt` 9.0.0 package (was `mparticle-apple-integration-rokt` 8.3.2).
+- **BREAKING**: `MParticleOptions.LocationTracking` is now Android-only; it is silently ignored on iOS because Apple SDK 9 removed `beginLocationTracking:` / `endLocationTracking`.
+- **BREAKING** (iOS binding surface): Renamed `iOSBinding.MPRoktEmbeddedView` to `iOSBinding.RoktEmbeddedView`; the factory `CreateMPRoktEmbeddedView()` was removed in favor of direct construction.
+- **BREAKING** (iOS binding surface): Removed `iOSBinding.MPProduct.UnitPrice`; use `iOSBinding.MPProduct.Price` (`NSNumber`) instead. The cross-platform `MParticle.Maui.Sdk.Product.UnitPrice` is unchanged.
+- iOS binding is now built as a static SPM product; `mParticle_Apple_SDK.xcframework` and `Rokt_Widget.xcframework` are no longer copied as separate resources.
+
+### Fixed
+
+- iOS `RoktPlacementClosed` now forwards the placement identifier to the `RoktEventCallback.OnUnLoad` handler instead of a hardcoded `"Unknown"`, matching the pattern used for `RoktEmbeddedSizeChanged` and the behavior of the sibling Flutter and React Native SDKs.
+
 ## [4.1.1] - 2026-03-20
 
 ### Fixed

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt/mParticle.Maui.Kits.Rokt.csproj
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt/mParticle.Maui.Kits.Rokt.csproj
@@ -221,22 +221,20 @@
         <None Include="**\android\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     </ItemGroup>
 
-    <!-- Copy Rokt_Widget.xcframework and mParticleRoktBindingiOS.xcframework to resources after Build -->
+    <!-- Copy mParticleRoktBindingiOS.xcframework to resources after Build -->
+    <!-- Note: Rokt-Widget and mParticle-Rokt are source-based SPM packages, so their symbols -->
+    <!-- are statically linked into mParticleRoktBindingiOS.xcframework via mParticleSPM. -->
     <Target Name="CopyRoktWidgetFramework" AfterTargets="Build" Condition="$(TargetFramework.Contains('ios'))">
         <PropertyGroup>
             <_RoktResourcesPath>$(OutputPath)MParticle.Maui.Kits.Rokt.resources</_RoktResourcesPath>
             <_RoktBindingXcFrameworkPath>$(MSBuildProjectDirectory)/obj/$(Configuration)/$(TargetFramework)/xcode/mParticleRoktBinding-*/xcframeworks/mParticleRoktBindingiOS.xcframework</_RoktBindingXcFrameworkPath>
         </PropertyGroup>
         <MakeDir Directories="$(_RoktResourcesPath)" />
-        <!-- Copy Rokt_Widget.xcframework from SPM DerivedData -->
-        <Exec Command="cp -R $(HOME)/Library/Developer/Xcode/DerivedData/mParticleRoktBinding-*/SourcePackages/artifacts/rokt-sdk-ios/Rokt_Widget/Rokt_Widget.xcframework &quot;$(_RoktResourcesPath)/&quot;" ContinueOnError="true" />
-        <!-- Copy mParticleRoktBindingiOS.xcframework (MPKitRokt) from Xcode build output -->
         <Exec Command="cp -R $(_RoktBindingXcFrameworkPath) &quot;$(_RoktResourcesPath)/&quot;" ContinueOnError="true" />
-        <!-- Copy manifest when both frameworks exist -->
-        <Copy 
-            SourceFiles="$(MSBuildThisFileDirectory)manifest.template" 
+        <Copy
+            SourceFiles="$(MSBuildThisFileDirectory)manifest.template"
             DestinationFiles="$(_RoktResourcesPath)/manifest"
-            Condition="Exists('$(_RoktResourcesPath)/Rokt_Widget.xcframework') And Exists('$(_RoktResourcesPath)/mParticleRoktBindingiOS.xcframework')"
+            Condition="Exists('$(_RoktResourcesPath)/mParticleRoktBindingiOS.xcframework')"
             SkipUnchangedFiles="true" />
     </Target>
 

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleRoktBinding/mParticleRoktBinding.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleRoktBinding/mParticleRoktBinding.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
       }
     },
     {
+      "identity" : "mp-apple-integration-rokt",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mparticle-integrations/mp-apple-integration-rokt.git",
+      "state" : {
+        "revision" : "bcd5582584079c76171c1cbf5d767a230ab147a8",
+        "version" : "9.0.0"
+      }
+    },
+    {
       "identity" : "mparticle-apple-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mParticle/mparticle-apple-sdk",

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleRoktBinding/mParticleRoktBinding.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleRoktBinding/mParticleRoktBinding.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "984067f045167c47dae622c44a6946459dde847c3d54b5b61193238c32b9ef3e",
+  "originHash" : "bc383cacdce12c953daa107fc621569c80e289569522f778fb697fe7ebf0f949",
   "pins" : [
     {
-      "identity" : "mparticle-apple-integration-rokt",
+      "identity" : "dcui-swift-schema",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mparticle-integrations/mparticle-apple-integration-rokt.git",
+      "location" : "https://github.com/ROKT/dcui-swift-schema.git",
       "state" : {
-        "revision" : "0a3b83fd60df0c272beaa8411fbf4c3418ff95b6",
-        "version" : "8.3.2"
+        "revision" : "ae2a6a8536acf641f1a3576fef5a6be730a3d5b0",
+        "version" : "2.4.0"
       }
     },
     {
@@ -15,8 +15,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mParticle/mparticle-apple-sdk",
       "state" : {
-        "revision" : "dffa5b707b0b1523a54f9a4bbf1c5e3056bf5948",
-        "version" : "8.40.0"
+        "revision" : "0bed61c5588bedf5ec120717c3c54b5176c73b29",
+        "version" : "9.0.0"
+      }
+    },
+    {
+      "identity" : "rokt-contracts-apple",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ROKT/rokt-contracts-apple.git",
+      "state" : {
+        "revision" : "ca2ff1061f5d2fe8d611c7ac17e2af8c931734b0",
+        "version" : "0.1.3"
       }
     },
     {
@@ -24,8 +33,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ROKT/rokt-sdk-ios",
       "state" : {
-        "revision" : "0656a9b02cd17fa580c31c99f001ed2ffc080817",
-        "version" : "4.14.2"
+        "revision" : "dc52e950b24050dc9912988006bfb61ab4facdde",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "rokt-ux-helper-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ROKT/rokt-ux-helper-ios.git",
+      "state" : {
+        "revision" : "2cc3b79527b9399dae5e596a33b3e750cc42ce86",
+        "version" : "0.9.1"
       }
     }
   ],

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleSPM/Package.swift
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleSPM/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "mParticleSPM",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v15)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -17,14 +17,16 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/mparticle-integrations/mparticle-apple-integration-rokt.git", exact: "8.3.2")
+        .package(url: "https://github.com/mParticle/mparticle-apple-sdk", exact: "9.0.0"),
+        .package(path: "../../../../../../../../mparticle-apple-sdk/kits/rokt/rokt")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         .target(
             name: "mParticleSPM",
             dependencies: [
-                .product(name: "mParticle-Rokt", package: "mparticle-apple-integration-rokt")
+                .product(name: "mParticle-Apple-SDK", package: "mparticle-apple-sdk"),
+                .product(name: "mParticle-Rokt", package: "rokt")
             ]
         )
     ]

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleSPM/Package.swift
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleSPM/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/mParticle/mparticle-apple-sdk", exact: "9.0.0"),
-        .package(path: "../../../../../../../../mparticle-apple-sdk/kits/rokt/rokt")
+        .package(url: "https://github.com/mparticle-integrations/mp-apple-integration-rokt.git", exact: "9.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -26,7 +26,7 @@ let package = Package(
             name: "mParticleSPM",
             dependencies: [
                 .product(name: "mParticle-Apple-SDK", package: "mparticle-apple-sdk"),
-                .product(name: "mParticle-Rokt", package: "rokt")
+                .product(name: "mParticle-Rokt", package: "mp-apple-integration-rokt")
             ]
         )
     ]

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleSPM/Sources/mParticleSPM/mParticleSPM.swift
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleSPM/Sources/mParticleSPM/mParticleSPM.swift
@@ -14,12 +14,10 @@
 import Foundation
 @_exported import mParticle_Apple_SDK
 @_exported import mParticle_Rokt_Swift
-@_exported import Rokt_Widget
 
-/// SPM wrapper for mParticle_Rokt_Swift dependency
+/// SPM wrapper for mParticle core and Rokt kit dependencies
 /// This module provides a clean interface to the Rokt iOS SDK
 /// and allows for easy version management through Swift Package Manager
 public struct MParticleSPM {
-    // This is a wrapper module that re-exports mParticle_Rokt_Swift
-    // All functionality is available through the imported mParticle_Apple_SDK module
+    // This is a wrapper module that re-exports the underlying SDK modules.
 }

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt/manifest.template
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt/manifest.template
@@ -1,10 +1,5 @@
 <BindingAssembly>
-  <!-- mParticleRoktBinding first: contains MPKitRokt, required at mParticle init -->
   <NativeReference Name="mParticleRoktBindingiOS.xcframework">
-    <Kind>Framework</Kind>
-    <SmartLink>false</SmartLink>
-  </NativeReference>
-  <NativeReference Name="Rokt_Widget.xcframework">
     <Kind>Framework</Kind>
     <SmartLink>false</SmartLink>
   </NativeReference>

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,3 +1,71 @@
-# Migration guide
+<!-- markdownlint-disable MD024 -->
 
-No released versions currently require migration steps and should offer a smooth journey when upgrading.
+# Migration Guides
+
+This document describes upgrade steps for breaking changes in the mParticle MAUI SDK. It only covers changes that require action on the MAUI side (csproj settings, public C# API, or the iOS binding surface consumed by your host app).
+
+For changes in the underlying native iOS SDK (database migration, deprecated `UIApplicationDelegate` methods, removed `AppDelegateProxy`, regional routing / ATS, Rokt Swift/Objective-C type renames, etc.), refer to the [mParticle Apple SDK 9 migration guide](https://github.com/mParticle/mparticle-apple-sdk/blob/main/MIGRATING.md#migrating-from-versions--900).
+
+## Migrating from versions < 5.0.0
+
+Version 5.0.0 wraps the mParticle Apple SDK 9 on iOS and the matching `mp-apple-integration-rokt` 9.0.0 Rokt integration. Android behavior is unchanged. No C# source changes are required for most apps, but the iOS build configuration and one MAUI option (`LocationTracking`) behave differently.
+
+### iOS deployment target raised to 15
+
+The binding now requires iOS 15+. Update the following in your MAUI app:
+
+- In your `.csproj`, raise `SupportedOSPlatformVersion` for iOS:
+
+  ```xml
+  <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
+  ```
+
+- If your app's `Info.plist` sets `MinimumOSVersion`, raise it to `15.0`.
+
+### iOS native dependencies updated
+
+The iOS SPM manifests that ship with the binding now pull:
+
+| Package                          | Before (4.x)                             | After (5.0.0)                     |
+| -------------------------------- | ---------------------------------------- | --------------------------------- |
+| mParticle Apple SDK              | `mparticle-apple-sdk` 8.40.0             | `mparticle-apple-sdk` 9.0.0       |
+| Rokt integration (Rokt kit only) | `mparticle-apple-integration-rokt` 8.3.2 | `mp-apple-integration-rokt` 9.0.0 |
+
+Two things to note:
+
+1. **The Rokt integration repository was renamed** from `mparticle-apple-integration-rokt` to `mp-apple-integration-rokt`. If your iOS project pins this package directly (outside of the MAUI binding), update the URL.
+2. The iOS binding is now built as a **static** SPM product, and `mParticle_Apple_SDK.xcframework` / `Rokt_Widget.xcframework` are no longer copied as separate resources — their symbols are statically linked into `mParticleBindingiOS.xcframework` and `mParticleRoktBindingiOS.xcframework` respectively. If you had custom MSBuild targets that referenced those side-by-side xcframeworks, remove them.
+
+### `MParticleOptions.LocationTracking` is now Android-only
+
+The `LocationTracking` option on `MParticleOptions` still exists for API compatibility, but on iOS it is now a **no-op** — the underlying `beginLocationTracking:` / `endLocationTracking` selectors were removed in mParticle Apple SDK 9.
+
+Before (4.x) — worked on both platforms:
+
+```csharp
+var options = new MParticleOptions
+{
+    LocationTracking = new LocationTracking("GPS", 100, 350, 22),
+    // ...
+};
+```
+
+After (5.0.0) — same code compiles and runs, but `LocationTracking` is only honored on Android. No action is required unless your app specifically relies on iOS location tracking via this API; in that case, opt into Core Location directly from your iOS host and forward any relevant data as user attributes.
+
+### iOS binding renamed: `MPRoktEmbeddedView` → `RoktEmbeddedView`
+
+This only matters if you referenced `Bindings.iOS` types directly in your C# code (most apps don't — they go through `MParticle.Maui.Sdk.RoktEmbeddedView`).
+
+| Before (4.x)                                               | After (5.0.0)                       |
+| ---------------------------------------------------------- | ----------------------------------- |
+| `iOSBinding.MPRoktEmbeddedView`                            | `iOSBinding.RoktEmbeddedView`       |
+| `iOSBinding.MPRoktEmbeddedView.CreateMPRoktEmbeddedView()` | `new iOSBinding.RoktEmbeddedView()` |
+
+`MParticle.Maui.Sdk.RoktEmbeddedView` (the cross-platform MAUI view) is unchanged — keep using it directly in XAML / code as before.
+
+### iOS `MPProduct.UnitPrice` binding removed
+
+Again, only relevant if you used `Bindings.iOS.MPProduct` directly.
+
+- `iOSBinding.MPProduct.UnitPrice` was removed. Use `iOSBinding.MPProduct.Price` (an `NSNumber`) instead.
+- The cross-platform `MParticle.Maui.Sdk.Product.UnitPrice` is unchanged.

--- a/Sdk/MParticle.Maui.Sdk/MParticle.Maui.Sdk.csproj
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.Maui.Sdk.csproj
@@ -117,22 +117,20 @@
         <None Include="**\android\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     </ItemGroup>
 
-    <!-- Copy mParticle_Apple_SDK.xcframework and mParticleBindingiOS.xcframework to resources after Build -->
+    <!-- Copy mParticleBindingiOS.xcframework to resources after Build -->
+    <!-- Note: mParticle-Apple-SDK v9 is source-based (not a binary target), so its symbols -->
+    <!-- are statically linked into mParticleBindingiOS.xcframework via mParticleSPM. -->
     <Target Name="CopymParticleAppleSDKFramework" AfterTargets="Build" Condition="$(TargetFramework.Contains('ios'))">
         <PropertyGroup>
             <_SdkResourcesPath>$(OutputPath)MParticle.Maui.Sdk.resources</_SdkResourcesPath>
             <_BindingXcFrameworkPath>$(MSBuildProjectDirectory)/obj/$(Configuration)/$(TargetFramework)/xcode/mParticleBinding-*/xcframeworks/mParticleBindingiOS.xcframework</_BindingXcFrameworkPath>
         </PropertyGroup>
         <MakeDir Directories="$(_SdkResourcesPath)" />
-        <!-- Copy mParticle_Apple_SDK.xcframework from SPM DerivedData -->
-        <Exec Command="cp -R $(HOME)/Library/Developer/Xcode/DerivedData/mParticleBinding-*/SourcePackages/artifacts/mparticle-apple-sdk/mParticle_Apple_SDK/mParticle_Apple_SDK.xcframework &quot;$(_SdkResourcesPath)/&quot;" ContinueOnError="true" />
-        <!-- Copy mParticleBindingiOS.xcframework (contains mParticleSPM) from Xcode build output -->
         <Exec Command="cp -R $(_BindingXcFrameworkPath) &quot;$(_SdkResourcesPath)/&quot;" ContinueOnError="true" />
-        <!-- Copy manifest when both frameworks exist -->
-        <Copy 
-            SourceFiles="$(MSBuildThisFileDirectory)manifest.template" 
+        <Copy
+            SourceFiles="$(MSBuildThisFileDirectory)manifest.template"
             DestinationFiles="$(_SdkResourcesPath)/manifest"
-            Condition="Exists('$(_SdkResourcesPath)/mParticle_Apple_SDK.xcframework') And Exists('$(_SdkResourcesPath)/mParticleBindingiOS.xcframework')"
+            Condition="Exists('$(_SdkResourcesPath)/mParticleBindingiOS.xcframework')"
             SkipUnchangedFiles="true" />
     </Target>
 

--- a/Sdk/MParticle.Maui.Sdk/MParticle.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.cs
@@ -339,7 +339,7 @@ public class RoktApiWrapper : RoktApi
     }
 }
 
-public class RoktEmbeddedViewHandler : ViewHandler<RoktEmbeddedView, iOSBinding.MPRoktEmbeddedView>
+public class RoktEmbeddedViewHandler : ViewHandler<RoktEmbeddedView, iOSBinding.RoktEmbeddedView>
 {
     public static IPropertyMapper<RoktEmbeddedView, RoktEmbeddedViewHandler> PropertyMapper = 
         new PropertyMapper<RoktEmbeddedView, RoktEmbeddedViewHandler>(ViewHandler.ViewMapper);
@@ -348,9 +348,9 @@ public class RoktEmbeddedViewHandler : ViewHandler<RoktEmbeddedView, iOSBinding.
     {
     }
 
-    protected override iOSBinding.MPRoktEmbeddedView CreatePlatformView()
+    protected override iOSBinding.RoktEmbeddedView CreatePlatformView()
     {
-        return iOSBinding.MPRoktEmbeddedView.CreateMPRoktEmbeddedView();
+        return iOSBinding.RoktEmbeddedView.CreateRoktEmbeddedView();
     }
 }
 

--- a/Sdk/MParticle.Maui.Sdk/MParticle.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.cs
@@ -102,14 +102,8 @@ public class MParticleSDKImpl : MParticleSDK
         iOSBinding.MParticle.SetWrapperSdkInternal(iOSBinding.MPWrapperSdk.MPWrapperSdkMaui, version);
         
         mparticle.LogLevel = Utils.ConvertToMpLogLevel(options.LogLevel);
-        if (options.LocationTracking != null && options.LocationTracking.Enabled)
-        {
-            mparticle.BeginLocationTracking(options.LocationTracking.MinDistance, options.LocationTracking.MinDistance);
-        }
-        else
-        {
-            mparticle.EndLocationTracking();
-        }
+        // mParticle Apple SDK 9 removed begin/end location tracking selectors.
+        // Keep LocationTracking as Android-only behavior for now.
         if (options.PushRegistration != null && options.PushRegistration.IOSToken != null)
         {
             mparticle.PushNotificationToken = options.PushRegistration.IOSToken;
@@ -350,7 +344,7 @@ public class RoktEmbeddedViewHandler : ViewHandler<RoktEmbeddedView, iOSBinding.
 
     protected override iOSBinding.RoktEmbeddedView CreatePlatformView()
     {
-        return iOSBinding.RoktEmbeddedView.CreateRoktEmbeddedView();
+        return new iOSBinding.RoktEmbeddedView();
     }
 }
 

--- a/Sdk/MParticle.Maui.Sdk/MParticle.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.cs
@@ -344,7 +344,9 @@ public class RoktEmbeddedViewHandler : ViewHandler<RoktEmbeddedView, iOSBinding.
 
     protected override iOSBinding.RoktEmbeddedView CreatePlatformView()
     {
-        return new iOSBinding.RoktEmbeddedView();
+        var embeddedView = new iOSBinding.RoktEmbeddedView();
+        embeddedView.TranslatesAutoresizingMaskIntoConstraints = false;
+        return embeddedView;
     }
 }
 

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
@@ -1114,19 +1114,19 @@ namespace mParticle.MAUI.iOSBinding {
         MPRokt Rokt { get; }
     }
 
-    // typedef NS_ENUM(NSInteger, MPColorMode)
+    // typedef NS_ENUM(NSInteger, RoktColorMode)
     [Native]
-    public enum MPColorMode : long
+    public enum RoktColorMode : long
     {
         Light = 0,
         Dark = 1,
         System = 2
     }
 
-    // @interface MPRoktConfig : NSObject
+    // @interface RoktConfig : NSObject
     [BaseType(typeof(NSObject))]
     [Protocol]
-    interface MPRoktConfig
+    interface RoktConfig
     {
         // @property (nonatomic, copy, nullable) NSNumber *cacheDuration;
         [NullAllowed, Export("cacheDuration", ArgumentSemantic.Copy)]
@@ -1137,44 +1137,73 @@ namespace mParticle.MAUI.iOSBinding {
         NSDictionary<NSString, NSString> CacheAttributes { get; set; }
     }
 
-    // @interface MPRoktEmbeddedView : UIView
+    // @interface RoktEmbeddedView : UIView
     [BaseType(typeof(UIView))]
-    interface MPRoktEmbeddedView
+    interface RoktEmbeddedView
     {
         // @property (nonatomic, strong) NSString * _Nonnull identifier;
         [Export("identifier", ArgumentSemantic.Strong)]
         string Identifier { get; set; }
 
-        // +(MPRoktEmbeddedView * _Nonnull)createMPRoktEmbeddedView __attribute__((warn_unused_result("")));
+        // +(RoktEmbeddedView * _Nonnull)createRoktEmbeddedView __attribute__((warn_unused_result("")));
         [Static]
-        [Export("createMPRoktEmbeddedView")]
-        MPRoktEmbeddedView CreateMPRoktEmbeddedView();
+        [Export("createRoktEmbeddedView")]
+        RoktEmbeddedView CreateRoktEmbeddedView();
     }
 
-    // @interface MPRoktEventCallback : NSObject
+    // @interface RoktEvent : NSObject
     [BaseType(typeof(NSObject))]
     [Protocol]
-    interface MPRoktEventCallback
+    interface RoktEvent
     {
-        // @property (nonatomic, copy, nullable) void (^onLoad)(void);
-        [NullAllowed, Export("onLoad", ArgumentSemantic.Copy)]
-        Action OnLoad { get; set; }
+    }
 
-        // @property (nonatomic, copy, nullable) void (^onUnLoad)(void);
-        [NullAllowed, Export("onUnLoad", ArgumentSemantic.Copy)]
-        Action OnUnLoad { get; set; }
+    // @interface RoktShowLoadingIndicator : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktShowLoadingIndicator
+    {
+    }
 
-        // @property (nonatomic, copy, nullable) void (^onShouldShowLoadingIndicator)(void);
-        [NullAllowed, Export("onShouldShowLoadingIndicator", ArgumentSemantic.Copy)]
-        Action OnShouldShowLoadingIndicator { get; set; }
+    // @interface RoktHideLoadingIndicator : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktHideLoadingIndicator
+    {
+    }
 
-        // @property (nonatomic, copy, nullable) void (^onShouldHideLoadingIndicator)(void);
-        [NullAllowed, Export("onShouldHideLoadingIndicator", ArgumentSemantic.Copy)]
-        Action OnShouldHideLoadingIndicator { get; set; }
+    // @interface RoktPlacementReady : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktPlacementReady
+    {
+        // @property (nonatomic, strong, nullable) NSString *identifier;
+        [NullAllowed, Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+    }
 
-        // @property (nonatomic, copy, nullable) void (^onEmbeddedSizeChange)(NSString * _Nonnull, CGFloat);
-        [NullAllowed, Export("onEmbeddedSizeChange", ArgumentSemantic.Copy)]
-        Action<NSString, nfloat> OnEmbeddedSizeChange { get; set; }
+    // @interface RoktPlacementClosed : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktPlacementClosed
+    {
+        // @property (nonatomic, strong, nullable) NSString *identifier;
+        [NullAllowed, Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+    }
+
+    // @interface RoktEmbeddedSizeChanged : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktEmbeddedSizeChanged
+    {
+        // @property (nonatomic, strong, nonnull) NSString *identifier;
+        [Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+
+        // @property (nonatomic, assign) CGFloat updatedHeight;
+        [Export("updatedHeight")]
+        nfloat UpdatedHeight { get; }
     }
 
     // @interface MPRokt : NSObject
@@ -1182,12 +1211,40 @@ namespace mParticle.MAUI.iOSBinding {
     [Protocol]
     interface MPRokt
     {
-        // -(void)selectPlacements:(NSString * _Nonnull)identifier attributes:(NSDictionary<NSString *, NSString *> * _Nullable)attributes embeddedViews:(NSDictionary<NSString *, MPRoktEmbeddedView *> * _Nullable)embeddedViews config:(MPRoktConfig * _Nullable)config callbacks:(MPRoktEventCallback * _Nullable)callbacks;
-        [Export("selectPlacements:attributes:embeddedViews:config:callbacks:")]
-        void SelectPlacements(string identifier, 
+        // -(void)selectPlacements:(NSString * _Nonnull)identifier attributes:(NSDictionary<NSString *, NSString *> * _Nullable)attributes;
+        [Export("selectPlacements:attributes:")]
+        void SelectPlacements(string identifier, [NullAllowed] NSDictionary<NSString, NSString> attributes);
+
+        // -(void)selectPlacements:(NSString * _Nonnull)identifier attributes:(NSDictionary<NSString *, NSString *> * _Nullable)attributes embeddedViews:(NSDictionary<NSString *, RoktEmbeddedView *> * _Nullable)embeddedViews config:(RoktConfig * _Nullable)config onEvent:(void (^ _Nullable)(RoktEvent * _Nonnull))onEvent;
+        [Export("selectPlacements:attributes:embeddedViews:config:onEvent:")]
+        void SelectPlacements(string identifier,
             [NullAllowed] NSDictionary<NSString, NSString> attributes,
             [NullAllowed] NSDictionary embeddedViews,
-            [NullAllowed] MPRoktConfig config,
-            [NullAllowed] MPRoktEventCallback callbacks);
+            [NullAllowed] RoktConfig config,
+            [NullAllowed] Action<RoktEvent> onEvent);
+
+        // -(void)purchaseFinalized:(NSString * _Nonnull)identifier catalogItemId:(NSString * _Nonnull)catalogItemId success:(BOOL)success;
+        [Export("purchaseFinalized:catalogItemId:success:")]
+        void PurchaseFinalized(string identifier, string catalogItemId, bool success);
+
+        // -(void)events:(NSString * _Nonnull)identifier onEvent:(void (^ _Nullable)(RoktEvent * _Nonnull))onEvent;
+        [Export("events:onEvent:")]
+        void Events(string identifier, [NullAllowed] Action<RoktEvent> onEvent);
+
+        // -(void)globalEvents:(void (^ _Nonnull)(RoktEvent * _Nonnull))onEvent;
+        [Export("globalEvents:")]
+        void GlobalEvents(Action<RoktEvent> onEvent);
+
+        // -(void)close;
+        [Export("close")]
+        void Close();
+
+        // -(void)setSessionId:(NSString * _Nonnull)sessionId;
+        [Export("setSessionId:")]
+        void SetSessionId(string sessionId);
+
+        // -(NSString * _Nullable)getSessionId;
+        [NullAllowed, Export("getSessionId")]
+        string GetSessionId();
     }
 }

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
@@ -327,10 +327,6 @@ namespace mParticle.MAUI.iOSBinding {
         // @property (readwrite, nonatomic) double totalAmount __attribute__((deprecated("use MPTransactionAttributes.revenue instead")));
         [Export("totalAmount")]
         double TotalAmount { get; set; }
-
-        // @property (readwrite, nonatomic) double unitPrice __attribute__((deprecated("use the price property instead")));
-        [Export("unitPrice")]
-        double UnitPrice { get; set; }
     }
 
     // @interface MPCart : NSObject <NSCoding>
@@ -761,10 +757,6 @@ namespace mParticle.MAUI.iOSBinding {
         [Export("environment", ArgumentSemantic.Assign)]
         MPEnvironment Environment { get; set; }
 
-        // @property(nonatomic, unsafe_unretained, readwrite) BOOL proxyAppDelegate;
-        [Export("proxyAppDelegate", ArgumentSemantic.Assign)]
-        bool ProxyAppDelegate { get; set; }
-
         // @property(nonatomic, unsafe_unretained, readwrite) BOOL automaticSessionTracking;
         [Export("automaticSessionTracking", ArgumentSemantic.Assign)]
         bool AutomaticSessionTracking { get; set; }
@@ -1033,26 +1025,6 @@ namespace mParticle.MAUI.iOSBinding {
         [Export("kitInstance:completionHandler:")]
         void KitInstance(NSNumber kitCode, Action<NSObject> completionHandler);
 
-        // @property (nonatomic, unsafe_unretained) BOOL backgroundLocationTracking;
-        [Export("backgroundLocationTracking")]
-        bool BackgroundLocationTracking { get; set; }
-
-        // @property (nonatomic, strong) CLLocation * _Nullable location;
-        [NullAllowed, Export("location", ArgumentSemantic.Strong)]
-        CLLocation Location { get; set; }
-
-        // -(void)beginLocationTracking:(CLLocationAccuracy)accuracy minDistance:(CLLocationDistance)distanceFilter;
-        [Export("beginLocationTracking:minDistance:")]
-        void BeginLocationTracking(double accuracy, double distanceFilter);
-
-        // -(void)beginLocationTracking:(CLLocationAccuracy)accuracy minDistance:(CLLocationDistance)distanceFilter authorizationRequest:(MPLocationAuthorizationRequest)authorizationRequest;
-        [Export("beginLocationTracking:minDistance:authorizationRequest:")]
-        void BeginLocationTracking(double accuracy, double distanceFilter, MPLocationAuthorizationRequest authorizationRequest);
-
-        // -(void)endLocationTracking;
-        [Export("endLocationTracking")]
-        void EndLocationTracking();
-
         // -(void)excludeURLFromNetworkPerformanceMeasuring:(NSURL * _Nonnull)url;
         [Export("excludeURLFromNetworkPerformanceMeasuring:")]
         void ExcludeURLFromNetworkPerformanceMeasuring(NSUrl url);
@@ -1144,11 +1116,6 @@ namespace mParticle.MAUI.iOSBinding {
         // @property (nonatomic, strong) NSString * _Nonnull identifier;
         [Export("identifier", ArgumentSemantic.Strong)]
         string Identifier { get; set; }
-
-        // +(RoktEmbeddedView * _Nonnull)createRoktEmbeddedView __attribute__((warn_unused_result("")));
-        [Static]
-        [Export("createRoktEmbeddedView")]
-        RoktEmbeddedView CreateRoktEmbeddedView();
     }
 
     // @interface RoktEvent : NSObject

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
@@ -261,8 +261,8 @@ namespace mParticle.MAUI.iOS.Utils
                     case iOSBinding.RoktPlacementReady:
                         callbacks?.OnLoad?.Invoke();
                         break;
-                    case iOSBinding.RoktPlacementClosed:
-                        callbacks?.OnUnLoad?.Invoke("Unknown");
+                    case iOSBinding.RoktPlacementClosed closed:
+                        callbacks?.OnUnLoad?.Invoke(closed.Identifier ?? "Unknown");
                         break;
                     case iOSBinding.RoktEmbeddedSizeChanged sizeChanged:
                         callbacks?.OnEmbeddedSizeChange?.Invoke(sizeChanged.Identifier, (float)sizeChanged.UpdatedHeight);

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
@@ -220,12 +220,12 @@ namespace mParticle.MAUI.iOS.Utils
             });
         }
 
-        internal static iOSBinding.MPRoktConfig ConvertToMpRoktConfig(RoktConfig config)
+        internal static iOSBinding.RoktConfig ConvertToMpRoktConfig(RoktConfig config)
         {
             if (config == null)
                 return null;
 
-            var mpConfig = new iOSBinding.MPRoktConfig();
+            var mpConfig = new iOSBinding.RoktConfig();
             
             if (config.CacheDuration.HasValue)
                 mpConfig.CacheDuration = NSNumber.FromInt32(config.CacheDuration.Value);
@@ -235,40 +235,42 @@ namespace mParticle.MAUI.iOS.Utils
             return mpConfig;
         }
 
-        internal static iOSBinding.MPRoktEventCallback ConvertToMpRoktEventCallback(RoktEventCallback callbacks)
+        internal static Action<iOSBinding.RoktEvent> ConvertToMpRoktEventCallback(RoktEventCallback callbacks)
         {
             return ConvertToMpRoktEventCallback(callbacks, null);
         }
 
-        internal static iOSBinding.MPRoktEventCallback ConvertToMpRoktEventCallback(
+        internal static Action<iOSBinding.RoktEvent> ConvertToMpRoktEventCallback(
             RoktEventCallback callbacks, 
             Action<string, double> heightCallback)
         {
-            var mpCallback = new iOSBinding.MPRoktEventCallback();
-            
-            if (callbacks?.OnLoad != null)
-                mpCallback.OnLoad = callbacks.OnLoad;
-                
-            if (callbacks?.OnUnLoad != null)
-                mpCallback.OnUnLoad = () => callbacks.OnUnLoad?.Invoke("Unknown");
-                
-            if (callbacks?.OnShouldShowLoadingIndicator != null)
-                mpCallback.OnShouldShowLoadingIndicator = callbacks.OnShouldShowLoadingIndicator;
-                
-            if (callbacks?.OnShouldHideLoadingIndicator != null)
-                mpCallback.OnShouldHideLoadingIndicator = callbacks.OnShouldHideLoadingIndicator;
-                
-            // Combine both the user's callback and our internal height management
-            mpCallback.OnEmbeddedSizeChange = (identifier, size) => 
+            if (callbacks == null && heightCallback == null)
             {
-                // Call user's callback if provided
-                callbacks?.OnEmbeddedSizeChange?.Invoke(identifier, (float)size);
-                
-                // Call internal height management callback
-                heightCallback?.Invoke(identifier, (double)size);
+                return null;
+            }
+
+            return roktEvent =>
+            {
+                switch (roktEvent)
+                {
+                    case iOSBinding.RoktShowLoadingIndicator:
+                        callbacks?.OnShouldShowLoadingIndicator?.Invoke();
+                        break;
+                    case iOSBinding.RoktHideLoadingIndicator:
+                        callbacks?.OnShouldHideLoadingIndicator?.Invoke();
+                        break;
+                    case iOSBinding.RoktPlacementReady:
+                        callbacks?.OnLoad?.Invoke();
+                        break;
+                    case iOSBinding.RoktPlacementClosed:
+                        callbacks?.OnUnLoad?.Invoke("Unknown");
+                        break;
+                    case iOSBinding.RoktEmbeddedSizeChanged sizeChanged:
+                        callbacks?.OnEmbeddedSizeChange?.Invoke(sizeChanged.Identifier, (float)sizeChanged.UpdatedHeight);
+                        heightCallback?.Invoke(sizeChanged.Identifier, (double)sizeChanged.UpdatedHeight);
+                        break;
+                }
             };
-                    
-            return mpCallback;
         }
 
         internal static NSDictionary<NSString, NSString> ConvertToNSDictionary<T, V>(Dictionary<string, string> dictionary) where T : NSString where V : NSString
@@ -289,9 +291,9 @@ namespace mParticle.MAUI.iOS.Utils
             // Filter to only include views that have valid platform handlers and views
             var filteredViews = embeddedViews
                 .Where(kvp => kvp.Value?.Handler is { PlatformView: UIKit.UIView })
-                .Select(kvp => new KeyValuePair<string, iOSBinding.MPRoktEmbeddedView>(
+                .Select(kvp => new KeyValuePair<string, iOSBinding.RoktEmbeddedView>(
                     kvp.Key,
-                    (kvp.Value.Handler?.PlatformView as iOSBinding.MPRoktEmbeddedView)!
+                    (kvp.Value.Handler?.PlatformView as iOSBinding.RoktEmbeddedView)!
                 ))
                 .Where(kvp => kvp.Value != null)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
@@ -301,7 +303,7 @@ namespace mParticle.MAUI.iOS.Utils
                 return null;
             }
             
-            // Create NSDictionary with native MPRoktEmbeddedView instances
+            // Create NSDictionary with native RoktEmbeddedView instances
             var keys = filteredViews.Keys.ToArray();
             var values = filteredViews.Values.ToArray();
             

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
@@ -90,7 +90,6 @@ namespace mParticle.MAUI.iOS.Utils
             {
                 mpOptions.OnIdentifyComplete = ConvertToMpIdentifyCompleteListener(options.IdentityStateListener);
             }
-            mpOptions.ProxyAppDelegate = false; // NSProxy incompatible with .NET MAUI marshalling
             return mpOptions;
         }
 
@@ -99,7 +98,7 @@ namespace mParticle.MAUI.iOS.Utils
             var bindingProduct = new iOSBinding.MPProduct();
             bindingProduct.Sku = product.Sku;
             bindingProduct.Name = product.Name;
-            bindingProduct.UnitPrice = product.Price;
+            bindingProduct.Price = new NSNumber(product.Price);
             bindingProduct.Quantity = new NSNumber(product.Quantity);
             bindingProduct.Brand = product.Brand;
             bindingProduct.Category = product.Category;
@@ -124,7 +123,7 @@ namespace mParticle.MAUI.iOS.Utils
                     return null;
                 }
                 var customKeys = product.AllKeys.ToDictionary(key => key.ToString(), key => product.ObjectForKeyedSubscript(key.ToString()).ToString());
-                return new Product(product.Name, product.Sku, product.UnitPrice, product.Quantity.DoubleValue)
+                return new Product(product.Name, product.Sku, product.Price?.DoubleValue ?? 0, product.Quantity.DoubleValue)
                 {
                     Brand = product.Brand,
                     CouponCode = product.CouponCode,

--- a/Sdk/MParticle.Maui.Sdk/macios/native/mParticleBinding/mParticleBinding.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sdk/MParticle.Maui.Sdk/macios/native/mParticleBinding/mParticleBinding.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,22 @@
 {
-  "originHash" : "48e6da250f86ad208e0915bb05c11313bdacd02166253b9965d151395766c8d3",
+  "originHash" : "ce5bbb27789affa22311eedd9d0df13979c34b1728f8126b54ba4905e8615df8",
   "pins" : [
     {
       "identity" : "mparticle-apple-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mParticle/mparticle-apple-sdk",
       "state" : {
-        "revision" : "dffa5b707b0b1523a54f9a4bbf1c5e3056bf5948",
-        "version" : "8.40.0"
+        "revision" : "0bed61c5588bedf5ec120717c3c54b5176c73b29",
+        "version" : "9.0.0"
+      }
+    },
+    {
+      "identity" : "rokt-contracts-apple",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ROKT/rokt-contracts-apple.git",
+      "state" : {
+        "revision" : "ca2ff1061f5d2fe8d611c7ac17e2af8c931734b0",
+        "version" : "0.1.3"
       }
     }
   ],

--- a/Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM/Package.swift
+++ b/Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "mParticleSPM",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v15)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/mParticle/mparticle-apple-sdk", exact: "8.40.0")
+        .package(url: "https://github.com/mParticle/mparticle-apple-sdk", exact: "9.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM/Package.swift
+++ b/Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "mParticleSPM",
+            type: .static,
             targets: ["mParticleSPM"])
     ],
     dependencies: [

--- a/Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM/Sources/mParticleSPM/mParticleSPM.swift
+++ b/Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM/Sources/mParticleSPM/mParticleSPM.swift
@@ -23,28 +23,15 @@ public struct MParticleSPM {
     // All functionality is available through the imported mParticle_Apple_SDK module
 }
 
-/// Extension to MPRoktEmbeddedView to provide factory method for MAUI SDK
-public extension MPRoktEmbeddedView {
-    /// Factory method to create a new MPRoktEmbeddedView instance.
+/// Extension to RoktEmbeddedView to provide factory method for MAUI SDK
+public extension RoktEmbeddedView {
+    /// Factory method to create a new RoktEmbeddedView instance.
     /// This is the recommended way to create embedded views for use with Rokt placements in MAUI.
     ///
-    /// Uses runtime class lookup to ensure compatibility with dynamic linking scenarios
-    /// where multiple frameworks may reference the same class.
-    ///
-    /// - Returns: A new instance of MPRoktEmbeddedView configured for use with Rokt
-    @objc static func createMPRoktEmbeddedView() -> MPRoktEmbeddedView {
-        // Use runtime class lookup to ensure we get the exact class that exists in the runtime
-        // This avoids binding/class identity issues between different frameworks
-        let className = "MPRoktEmbeddedView"
+    /// - Returns: A new instance of RoktEmbeddedView configured for use with Rokt
+    @objc static func createRoktEmbeddedView() -> RoktEmbeddedView {
 
-        guard let embeddedViewClass = NSClassFromString(className) as? MPRoktEmbeddedView.Type else {
-            // Fallback to direct initialization if runtime lookup fails
-            let fallbackView = MPRoktEmbeddedView(frame: .zero)
-            fallbackView.translatesAutoresizingMaskIntoConstraints = false
-            return fallbackView
-        }
-
-        let embeddedView = embeddedViewClass.init(frame: .zero)
+        let embeddedView = RoktEmbeddedView(frame: .zero)
         embeddedView.translatesAutoresizingMaskIntoConstraints = false
 
         return embeddedView

--- a/Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM/Sources/mParticleSPM/mParticleSPM.swift
+++ b/Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM/Sources/mParticleSPM/mParticleSPM.swift
@@ -12,7 +12,6 @@
 //  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
 
 import Foundation
-import UIKit
 @_exported import mParticle_Apple_SDK
 
 /// SPM wrapper for mParticle_Apple_SDK dependency
@@ -21,19 +20,4 @@ import UIKit
 public struct MParticleSPM {
     // This is a wrapper module that re-exports mParticle_Apple_SDK
     // All functionality is available through the imported mParticle_Apple_SDK module
-}
-
-/// Extension to RoktEmbeddedView to provide factory method for MAUI SDK
-public extension RoktEmbeddedView {
-    /// Factory method to create a new RoktEmbeddedView instance.
-    /// This is the recommended way to create embedded views for use with Rokt placements in MAUI.
-    ///
-    /// - Returns: A new instance of RoktEmbeddedView configured for use with Rokt
-    @objc static func createRoktEmbeddedView() -> RoktEmbeddedView {
-
-        let embeddedView = RoktEmbeddedView(frame: .zero)
-        embeddedView.translatesAutoresizingMaskIntoConstraints = false
-
-        return embeddedView
-    }
 }

--- a/Sdk/MParticle.Maui.Sdk/manifest.template
+++ b/Sdk/MParticle.Maui.Sdk/manifest.template
@@ -1,8 +1,4 @@
 <BindingAssembly>
-  <NativeReference Name="mParticle_Apple_SDK.xcframework">
-    <Kind>Framework</Kind>
-    <SmartLink>false</SmartLink>
-  </NativeReference>
   <NativeReference Name="mParticleBindingiOS.xcframework">
     <Kind>Framework</Kind>
     <SmartLink>false</SmartLink>


### PR DESCRIPTION
## Background

- The mParticle Apple SDK 9.0 introduces breaking changes to the Rokt-related bindings and removes several deprecated APIs (e.g. `beginLocationTracking`/`endLocationTracking`, `MPProduct.unitPrice`, `MPRoktEmbeddedView`). The MAUI bindings were still pinned to SDK 8.40 and the old `MPRokt*` names, which caused both build and runtime crashes on iOS.

## What Has Changed

- Bumped the iOS SPM dependency to `mparticle-apple-sdk` 9.0.0 in both the core SDK and the Rokt kit, and raised the minimum iOS platform to 15 to match.
- Renamed the Swift factory and its callers from `MPRoktEmbeddedView` / `createMPRoktEmbeddedView` to `RoktEmbeddedView` / `createRoktEmbeddedView`, and simplified the Swift wrapper to construct `RoktEmbeddedView(frame: .zero)` directly.
- Updated iOS `ApiDefinitions.cs` and `Utils.cs` to match the new native surface:
  - Removed the deprecated `MParticle.beginLocationTracking` / `endLocationTracking` bindings and their callers.
  - Removed the deprecated `MPProduct.unitPrice` binding; conversions now use the `price` (`NSNumber`) property instead.
  - Synced `RoktEmbeddedView` handler to the new type and instantiation path.
- Aligned `MParticle.cs` initialization to no longer call removed location-tracking selectors on iOS.

## Screenshots/Video

- N/A

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally (core SDK + Rokt SampleApp on iOS simulator).

## Additional Notes

- Android behavior is unchanged; `LocationTracking` options remain Android-only for now since the Apple SDK removed the corresponding selectors.
- Follow-up work: refresh the Android binding baseline if the native Android SDK has similarly shifted APIs.
