### PR TITLE
feat: add optional Rokt Stripe payment extension kit for Shoppable Ads

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -29,6 +29,8 @@ env:
   SDK_PROJECT: MParticle.Maui.Sdk
   ROKT_KIT_PATH: Kits/rokt/Sdk/MParticle.Maui.Rokt
   ROKT_KIT_PROJECT: mParticle.Maui.Kits.Rokt
+  PAYMENTS_KIT_PATH: Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments
+  PAYMENTS_KIT_PROJECT: mParticle.Maui.Kits.Rokt.Payments
 
 jobs:
   publish-draft-release:
@@ -148,6 +150,26 @@ jobs:
       - name: Publish Rokt Kit to NuGet Test Gallery
         run: dotnet nuget push ${{ env.ROKT_KIT_PATH }}/bin/Release/${{ env.ROKT_KIT_PROJECT }}.${{ steps.full-version.outputs.full-version-with-suffix }}.nupkg --source https://apiint.nugettest.org/v3/index.json --api-key ${{steps.login.outputs.NUGET_API_KEY}}
 
+      - name: Resolve SPM dependencies for Rokt Payments Kit iOS binding
+        run: |
+          cd ${{ env.PAYMENTS_KIT_PATH }}/macios/native/mParticleRoktPaymentsBinding
+          xcodebuild -resolvePackageDependencies -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding
+
+      - name: Build Xcode project for Rokt Payments Kit iOS
+        run: |
+          cd ${{ env.PAYMENTS_KIT_PATH }}/macios/native/mParticleRoktPaymentsBinding
+          xcodebuild -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding -configuration Release -sdk iphoneos build
+          xcodebuild -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding -configuration Release -sdk iphonesimulator build
+
+      - name: Build Rokt Payments Kit
+        run: dotnet build ${{ env.PAYMENTS_KIT_PATH }}/${{ env.PAYMENTS_KIT_PROJECT }}.csproj -c Release -p:Version=${{ steps.full-version.outputs.full-version-with-suffix }}
+
+      - name: Pack Rokt Payments Kit
+        run: dotnet pack ${{ env.PAYMENTS_KIT_PATH }}/${{ env.PAYMENTS_KIT_PROJECT }}.csproj -c Release -p:Version=${{ steps.full-version.outputs.full-version-with-suffix }}
+
+      - name: Publish Rokt Payments Kit to NuGet Test Gallery
+        run: dotnet nuget push ${{ env.PAYMENTS_KIT_PATH }}/bin/Release/${{ env.PAYMENTS_KIT_PROJECT }}.${{ steps.full-version.outputs.full-version-with-suffix }}.nupkg --source https://apiint.nugettest.org/v3/index.json --api-key ${{steps.login.outputs.NUGET_API_KEY}}
+
       - name: Set .csproj version for SDK
         uses: vers-one/dotnet-project-version-updater@6d4de57b8f089d58a00b6ede1f3f05c77bb8e541 # v1.7
         with:
@@ -158,6 +180,12 @@ jobs:
         uses: vers-one/dotnet-project-version-updater@6d4de57b8f089d58a00b6ede1f3f05c77bb8e541 # v1.7
         with:
           file: ${{ env.ROKT_KIT_PATH }}/${{ env.ROKT_KIT_PROJECT }}.csproj
+          version: ${{ steps.bump-version.outputs.new_version }}
+
+      - name: Set .csproj version for Rokt Payments Kit
+        uses: vers-one/dotnet-project-version-updater@6d4de57b8f089d58a00b6ede1f3f05c77bb8e541 # v1.7
+        with:
+          file: ${{ env.PAYMENTS_KIT_PATH }}/${{ env.PAYMENTS_KIT_PROJECT }}.csproj
           version: ${{ steps.bump-version.outputs.new_version }}
 
       - name: Upload Package Artifact for SDK
@@ -171,6 +199,12 @@ jobs:
         with:
           name: ${{ env.ROKT_KIT_PROJECT }}.${{ steps.full-version.outputs.full-version-with-suffix }}.nupkg
           path: ${{ env.ROKT_KIT_PATH }}/bin/Release/${{ env.ROKT_KIT_PROJECT }}.${{ steps.full-version.outputs.full-version-with-suffix }}.nupkg
+
+      - name: Upload Package Artifact for Rokt Payments Kit
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.PAYMENTS_KIT_PROJECT }}.${{ steps.full-version.outputs.full-version-with-suffix }}.nupkg
+          path: ${{ env.PAYMENTS_KIT_PATH }}/bin/Release/${{ env.PAYMENTS_KIT_PROJECT }}.${{ steps.full-version.outputs.full-version-with-suffix }}.nupkg
 
       - name: Generate a token
         id: generate-token
@@ -189,7 +223,7 @@ jobs:
           commit-message: Create ${{ steps.bump-version.outputs.new_version }}
           branch: release/${{ steps.bump-version.outputs.new_version }}
           title: Prepare release ${{ steps.bump-version.outputs.new_version }}
-          add-paths: CHANGELOG.md, VERSION, ${{ env.SDK_PATH }}/${{ env.SDK_PROJECT }}.csproj, ${{ env.ROKT_KIT_PATH }}/${{ env.ROKT_KIT_PROJECT }}.csproj
+          add-paths: CHANGELOG.md, VERSION, ${{ env.SDK_PATH }}/${{ env.SDK_PROJECT }}.csproj, ${{ env.ROKT_KIT_PATH }}/${{ env.ROKT_KIT_PROJECT }}.csproj, ${{ env.PAYMENTS_KIT_PATH }}/${{ env.PAYMENTS_KIT_PROJECT }}.csproj
           base: main
           body: |
             Preparing for release ${{ steps.bump-version.outputs.new_version }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,6 +22,8 @@ env:
   SDK_PROJECT: MParticle.Maui.Sdk
   ROKT_KIT_PATH: Kits/rokt/Sdk/MParticle.Maui.Rokt
   ROKT_KIT_PROJECT: mParticle.Maui.Kits.Rokt
+  PAYMENTS_KIT_PATH: Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments
+  PAYMENTS_KIT_PROJECT: mParticle.Maui.Kits.Rokt.Payments
 
 jobs:
   trunk-check:
@@ -88,6 +90,20 @@ jobs:
       - name: Build Rokt Kit
         run: dotnet build ${{ env.ROKT_KIT_PATH }}/${{ env.ROKT_KIT_PROJECT }}.csproj
 
+      - name: Resolve SPM dependencies for Rokt Payments Kit iOS binding
+        run: |
+          cd ${{ env.PAYMENTS_KIT_PATH }}/macios/native/mParticleRoktPaymentsBinding
+          xcodebuild -resolvePackageDependencies -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding
+
+      - name: Build Xcode project for Rokt Payments Kit iOS
+        run: |
+          cd ${{ env.PAYMENTS_KIT_PATH }}/macios/native/mParticleRoktPaymentsBinding
+          xcodebuild -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding -configuration Debug -sdk iphoneos build
+          xcodebuild -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding -configuration Debug -sdk iphonesimulator build
+
+      - name: Build Rokt Payments Kit
+        run: dotnet build ${{ env.PAYMENTS_KIT_PATH }}/${{ env.PAYMENTS_KIT_PROJECT }}.csproj
+
       - name: Build Rokt Kit SampleApp
         run: dotnet build Kits/rokt/SampleApp/SampleApp.csproj
 
@@ -96,6 +112,9 @@ jobs:
 
       - name: Pack Rokt Kit
         run: dotnet pack ${{ env.ROKT_KIT_PATH }}/${{ env.ROKT_KIT_PROJECT }}.csproj
+
+      - name: Pack Rokt Payments Kit
+        run: dotnet pack ${{ env.PAYMENTS_KIT_PATH }}/${{ env.PAYMENTS_KIT_PROJECT }}.csproj
 
       - name: Find and rename SDK nupkg file
         run: |
@@ -138,6 +157,27 @@ jobs:
         with:
           name: ${{ env.ROKT_KIT_PROJECT }}.nupkg
           path: ${{ env.ROKT_KIT_PATH }}/bin/Release/${{ env.ROKT_KIT_PROJECT }}.nupkg
+
+      - name: Find and rename Rokt Payments Kit nupkg file
+        run: |
+          # Find the generated nupkg file
+          NUPKG_FILE=$(find ${{ env.PAYMENTS_KIT_PATH }}/bin/Release -name "*.nupkg" | head -1)
+          if [ -z "$NUPKG_FILE" ]; then
+            echo "No nupkg file found"
+            exit 1
+          fi
+          echo "Found nupkg file: $NUPKG_FILE"
+
+          # Rename to remove version number
+          RENAMED_FILE="${{ env.PAYMENTS_KIT_PATH }}/bin/Release/${{ env.PAYMENTS_KIT_PROJECT }}.nupkg"
+          cp "$NUPKG_FILE" "$RENAMED_FILE"
+          echo "Renamed to: $RENAMED_FILE"
+
+      - name: Upload Rokt Payments Kit Package Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.PAYMENTS_KIT_PROJECT }}.nupkg
+          path: ${{ env.PAYMENTS_KIT_PATH }}/bin/Release/${{ env.PAYMENTS_KIT_PROJECT }}.nupkg
 
   pr-notify:
     if: >

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -16,6 +16,8 @@ env:
   SDK_PROJECT: MParticle.Maui.Sdk
   ROKT_KIT_PATH: Kits/rokt/Sdk/MParticle.Maui.Rokt
   ROKT_KIT_PROJECT: mParticle.Maui.Kits.Rokt
+  PAYMENTS_KIT_PATH: Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments
+  PAYMENTS_KIT_PROJECT: mParticle.Maui.Kits.Rokt.Payments
 
 jobs:
   setup-and-version:
@@ -107,6 +109,26 @@ jobs:
       - name: Publish Rokt Kit to NuGet Gallery
         run: dotnet nuget push ${{ env.ROKT_KIT_PATH }}/bin/Release/${{ env.ROKT_KIT_PROJECT }}.${{ needs.setup-and-version.outputs.final_version }}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
 
+      - name: Resolve SPM dependencies for Rokt Payments Kit iOS binding
+        run: |
+          cd ${{ env.PAYMENTS_KIT_PATH }}/macios/native/mParticleRoktPaymentsBinding
+          xcodebuild -resolvePackageDependencies -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding
+
+      - name: Build Xcode project for Rokt Payments Kit iOS
+        run: |
+          cd ${{ env.PAYMENTS_KIT_PATH }}/macios/native/mParticleRoktPaymentsBinding
+          xcodebuild -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding -configuration Release -sdk iphoneos build
+          xcodebuild -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding -configuration Release -sdk iphonesimulator build
+
+      - name: Build Rokt Payments Kit
+        run: dotnet build ${{ env.PAYMENTS_KIT_PATH }}/${{ env.PAYMENTS_KIT_PROJECT }}.csproj -c Release
+
+      - name: Pack Rokt Payments Kit
+        run: dotnet pack ${{ env.PAYMENTS_KIT_PATH }}/${{ env.PAYMENTS_KIT_PROJECT }}.csproj -c Release
+
+      - name: Publish Rokt Payments Kit to NuGet Gallery
+        run: dotnet nuget push ${{ env.PAYMENTS_KIT_PATH }}/bin/Release/${{ env.PAYMENTS_KIT_PROJECT }}.${{ needs.setup-and-version.outputs.final_version }}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
+
       - name: Upload Package Artifact for SDK
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -118,6 +140,12 @@ jobs:
         with:
           name: ${{ env.ROKT_KIT_PROJECT }}.${{ needs.setup-and-version.outputs.final_version }}.nupkg
           path: ${{ env.ROKT_KIT_PATH }}/bin/Release/${{ env.ROKT_KIT_PROJECT }}.${{ needs.setup-and-version.outputs.final_version }}.nupkg
+
+      - name: Upload Package Artifact for Rokt Payments Kit
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.PAYMENTS_KIT_PROJECT }}.${{ needs.setup-and-version.outputs.final_version }}.nupkg
+          path: ${{ env.PAYMENTS_KIT_PATH }}/bin/Release/${{ env.PAYMENTS_KIT_PROJECT }}.${{ needs.setup-and-version.outputs.final_version }}.nupkg
 
       - uses: ffurrer2/extract-release-notes@9989ccec43d726ef05aa1cd7b2854fb96b6df6ab # v2.2.0
         id: extract-release-notes
@@ -133,6 +161,7 @@ jobs:
           artifacts: |
             ${{ env.SDK_PATH }}/bin/Release/mParticle.MAUI.${{ needs.setup-and-version.outputs.final_version }}.nupkg
             ${{ env.ROKT_KIT_PATH }}/bin/Release/${{ env.ROKT_KIT_PROJECT }}.${{ needs.setup-and-version.outputs.final_version }}.nupkg
+            ${{ env.PAYMENTS_KIT_PATH }}/bin/Release/${{ env.PAYMENTS_KIT_PROJECT }}.${{ needs.setup-and-version.outputs.final_version }}.nupkg
           makeLatest: true
           tag: ${{ needs.setup-and-version.outputs.final_version }}
           body: |

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ Desktop.ini
 
 # Xcode
 build/
+# Keep MSBuild .targets files that live in a `build/` folder inside a NuGet package.
+# NuGet convention: `build/<PackageId>.targets` is auto-imported by consumers.
+!Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/build/
+!Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/build/**
 *.pbxuser
 !default.pbxuser
 *.mode1v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This release upgrades the iOS binding to mParticle Apple SDK 9 and contains breaking changes. See [MIGRATING.md](./MIGRATING.md) for the full 4.x → 5.0 upgrade guide.
 
+### Added
+
+- iOS-only `RoktApi.SelectShoppableAds` C# API, wrapping the `selectShoppableAds:attributes:config:onEvent:` selector from mParticle Apple SDK 9. Android exposes a no-op bridge for API compatibility until native support lands, matching the Flutter and React Native SDKs. Requires a payment extension to be registered on the native iOS side.
+- `Show Rokt Shoppable Ads (iOS)` demo button in the Rokt sample app.
+
 ### Changed
 
 - **BREAKING**: iOS minimum deployment target raised from `11.0` to `15.0`.

--- a/Kits/rokt/SampleApp/MainPage.xaml
+++ b/Kits/rokt/SampleApp/MainPage.xaml
@@ -47,6 +47,13 @@
                 Clicked="OnShowRoktOverlayClicked"
                 HorizontalOptions="Fill" />
 
+            <Button
+                x:Name="ShowRoktShoppableAdsBtn"
+                Text="Show Rokt Shoppable Ads (iOS)"
+                SemanticProperties.Hint="Show Rokt Shoppable Ads overlay (iOS only)"
+                Clicked="OnShowRoktShoppableAdsClicked"
+                HorizontalOptions="Fill" />
+
             <sdk:RoktEmbeddedView
                 x:Name="Location1"/>
             

--- a/Kits/rokt/SampleApp/MainPage.xaml.cs
+++ b/Kits/rokt/SampleApp/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using mParticle.MAUI;
+using mParticle.MAUI.Rokt.Payments;
 using System.Collections.Generic;
 
 namespace SampleApp;
@@ -85,6 +86,11 @@ public partial class MainPage : ContentPage
         RoktKit.Register();
 
         MParticle.Instance.Initialize(options);
+
+        // Register the optional Rokt Stripe / Apple Pay payment extension (iOS only).
+        // Replace the merchant id with your own Apple Pay merchant identifier.
+        RoktStripePaymentExtension.Register("merchant.com.yourapp.rokt");
+
         InitializeBtn.Text = "mParticle Initialized!";
         InitializeBtn.IsEnabled = false; // Disable after initialization
 

--- a/Kits/rokt/SampleApp/MainPage.xaml.cs
+++ b/Kits/rokt/SampleApp/MainPage.xaml.cs
@@ -325,12 +325,25 @@ public partial class MainPage : ContentPage
 
         var attributes = new Dictionary<string, string>
         {
-            ["email"] = "test@gmail.com",
+            ["country"] = "US",
+            ["shippingstate"] = "NY",
+            ["shippingzipcode"] = "10001",
             ["firstname"] = "Jenny",
-            ["lastname"] = "Smith",
+            ["stripeApplePayAvailable"] = "true",
+            ["last4digits"] = "4444",
+            ["shippingaddress1"] = "123 Main St",
+            ["colormode"] = "LIGHT",
             ["billingzipcode"] = "07762",
-            ["confirmationref"] = "54321",
-            ["country"] = "US"
+            ["paymenttype"] = "ApplePay",
+            ["shippingcountry"] = "US",
+            ["sandbox"] = "true",
+            ["shippingaddress2"] = "Apt 4B",
+            ["confirmationref"] = "ORD-12345",
+            ["shippingcity"] = "New York",
+            ["newToApplePay"] = "false",
+            ["applePayCapabilities"] = "true",
+            ["lastname"] = "Smith",
+            ["email"] = "jenny.smith@example.com"
         };
 
         var callbacks = new RoktEventCallback

--- a/Kits/rokt/SampleApp/MainPage.xaml.cs
+++ b/Kits/rokt/SampleApp/MainPage.xaml.cs
@@ -317,4 +317,38 @@ public partial class MainPage : ContentPage
             callbacks: callbacks
         );
     }
+
+    private void OnShowRoktShoppableAdsClicked(object sender, EventArgs e)
+    {
+        Console.WriteLine("Show Rokt Shoppable Ads Called");
+        var mparticle = MParticle.Instance;
+
+        var attributes = new Dictionary<string, string>
+        {
+            ["email"] = "test@gmail.com",
+            ["firstname"] = "Jenny",
+            ["lastname"] = "Smith",
+            ["billingzipcode"] = "07762",
+            ["confirmationref"] = "54321",
+            ["country"] = "US"
+        };
+
+        var callbacks = new RoktEventCallback
+        {
+            OnLoad = () => Console.WriteLine("Rokt shoppable ads placement loaded"),
+            OnUnLoad = (reason) => Console.WriteLine($"Rokt shoppable ads placement unloaded with reason: {reason}"),
+            OnShouldShowLoadingIndicator = () => Console.WriteLine("Should show loading indicator"),
+            OnShouldHideLoadingIndicator = () => Console.WriteLine("Should hide loading indicator")
+        };
+
+        // Note: on iOS this requires a payment extension to be registered natively
+        // (see the Rokt kit docs for the one-time AppDelegate/Scene setup).
+        // On Android this call is a no-op until native support lands.
+        mparticle.Rokt.SelectShoppableAds(
+            identifier: "MSDKShoppableAdsLayout",
+            attributes: attributes,
+            config: null,
+            callbacks: callbacks
+        );
+    }
 }

--- a/Kits/rokt/SampleApp/SampleApp.csproj
+++ b/Kits/rokt/SampleApp/SampleApp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
@@ -60,9 +60,16 @@
         <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0"/>
-        <ProjectReference Include="../Sdk/MParticle.Maui.Rokt/MParticle.Maui.Kits.Rokt.csproj" />
-        <ProjectReference Include="../../../Sdk/mParticle.Maui.Sdk/mParticle.Maui.Sdk.csproj" />
+        <ProjectReference Include="../Sdk/MParticle.Maui.Rokt.Payments/mParticle.Maui.Kits.Rokt.Payments.csproj" />
     </ItemGroup>
+
+    <!--
+        Dev-build import of the Payments kit's build targets.
+        When consumed via NuGet this file is imported automatically;
+        here we import it explicitly because we use a ProjectReference.
+    -->
+    <Import Project="../Sdk/MParticle.Maui.Rokt.Payments/build/mParticle.Maui.Kits.Rokt.Payments.targets"
+            Condition="Exists('../Sdk/MParticle.Maui.Rokt.Payments/build/mParticle.Maui.Kits.Rokt.Payments.targets')" />
 
     <PropertyGroup>
         <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);../</RestoreAdditionalProjectSources>

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/LICENSE
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 mParticle Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/MParticle.Rokt.Payments.cs
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/MParticle.Rokt.Payments.cs
@@ -1,0 +1,40 @@
+namespace mParticle.MAUI.Rokt.Payments
+{
+#if __IOS__
+    using global::mParticle.MAUI.iOSBinding;
+    using global::mParticle.MAUI.Rokt.Payments.iOSBinding;
+#endif
+
+    /// <summary>
+    /// Registers the Rokt Stripe / Apple Pay payment extension with the mParticle Rokt kit.
+    /// Requires the core <c>mParticle.Maui.Kits.Rokt</c> package and the
+    /// <c>com.apple.developer.in-app-payments</c> entitlement (with your Apple Pay
+    /// merchant identifier) on iOS.
+    /// </summary>
+    public static class RoktStripePaymentExtension
+    {
+        /// <summary>
+        /// Creates a native Rokt Stripe payment extension and registers it with the
+        /// Rokt kit. Call once, after <c>MParticle.Instance.Initialize(options)</c>.
+        /// On Android this is a no-op and returns <c>false</c>.
+        /// </summary>
+        /// <param name="applePayMerchantId">Apple Pay merchant identifier (e.g. <c>merchant.com.yourapp.rokt</c>).</param>
+        /// <param name="countryCode">ISO country code. Defaults to <c>US</c>.</param>
+        /// <returns><c>true</c> if the extension was registered, <c>false</c> otherwise.</returns>
+        public static bool Register(string applePayMerchantId, string countryCode = "US")
+        {
+#if __IOS__
+            var ext = MPRoktStripePaymentExtension.Create(applePayMerchantId, countryCode);
+            if (ext is null)
+            {
+                return false;
+            }
+
+            MParticle.SharedInstance.Rokt.RegisterPaymentExtension(ext);
+            return true;
+#else
+            return false;
+#endif
+        }
+    }
+}

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/MParticle.Rokt.Payments.cs
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/MParticle.Rokt.Payments.cs
@@ -1,8 +1,9 @@
 namespace mParticle.MAUI.Rokt.Payments
 {
 #if __IOS__
-    using global::mParticle.MAUI.iOSBinding;
     using global::mParticle.MAUI.Rokt.Payments.iOSBinding;
+    using PaymentsBinding = global::mParticle.MAUI.Rokt.Payments.iOSBinding;
+    using CoreBinding = global::mParticle.MAUI.iOSBinding;
 #endif
 
     /// <summary>
@@ -24,13 +25,13 @@ namespace mParticle.MAUI.Rokt.Payments
         public static bool Register(string applePayMerchantId, string countryCode = "US")
         {
 #if __IOS__
-            var ext = MPRoktStripePaymentExtension.Create(applePayMerchantId, countryCode);
-            if (ext is null)
+            var ext = new PaymentsBinding.MPRoktStripePaymentExtension(applePayMerchantId, countryCode);
+            var rokt = CoreBinding.MParticle.SharedInstance?.Rokt;
+            if (rokt == null)
             {
                 return false;
             }
-
-            MParticle.SharedInstance.Rokt.RegisterPaymentExtension(ext);
+            rokt.RegisterPaymentExtension(ext);
             return true;
 #else
             return false;

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/NuGet.Config
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="maui-nativelibraryinterop" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/maui-nativelibraryinterop/nuget/v3/index.json" />
+    </packageSources>
+</configuration>

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/README.md
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/README.md
@@ -1,0 +1,20 @@
+# Rokt Payments .NET MAUI Kit
+
+## Overview
+
+Optional payment extension for the Rokt MAUI kit. Enables Apple Pay / Stripe
+flows inside Rokt Shoppable Ads. Depends on `mParticle.Maui.Kits.Rokt`.
+
+## Getting Started
+
+```csharp
+using mParticle.MAUI.Rokt.Payments;
+
+// Call once after MParticle.Instance.Initialize(options)
+RoktStripePaymentExtension.Register("merchant.com.yourapp.rokt");
+```
+
+## Supported Targets
+
+- .NET iOS (Apple Pay via Stripe)
+- .NET Android (no-op)

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/build/mParticle.Maui.Kits.Rokt.Payments.targets
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/build/mParticle.Maui.Kits.Rokt.Payments.targets
@@ -1,0 +1,41 @@
+<Project>
+
+    <!--
+        Remove transitive xcframeworks brought in by MParticle.Maui
+        and MParticle.Maui.Kits.Rokt from the final iOS app bundle.
+
+        The MParticle.Maui.Kits.Rokt.Payments kit ships a single "fat"
+        xcframework (mParticleRoktPaymentsBindingiOS.xcframework) that already
+        contains all symbols from the core mParticle Apple SDK and the Rokt
+        kit (via @_exported import in the Swift umbrella module). Leaving the
+        transitive xcframeworks in the bundle would cause duplicate
+        Objective-C class definitions at runtime (for example MPForwardRecord
+        and MPKitExecStatus would appear twice), leading to isKindOfClass:
+        assertion failures inside the core SDK.
+
+        The C# bindings from MParticle.Maui and MParticle.Maui.Kits.Rokt are
+        still referenced for compile-time type information; only their native
+        xcframeworks are stripped from the final app.
+
+        In the .NET iOS SDK, xcframeworks from transitive ProjectReferences
+        are resolved into the `_FrameworkNativeReference` item group by the
+        `_ComputeBundleLocation` target. We therefore hook just before
+        `_ComputeFrameworkFilesToPublish` (which turns that list into the
+        files actually copied into the .app bundle) and filter the
+        unwanted framework names out.
+    -->
+    <Target Name="ExcludeTransitiveMParticleXcframeworks"
+            BeforeTargets="_ComputeFrameworkFilesToPublish"
+            Condition="$(TargetFramework.Contains('ios'))">
+
+        <ItemGroup>
+            <_FrameworkNativeReference Remove="@(_FrameworkNativeReference)"
+                                       Condition="'%(Filename)' == 'mParticleBinding'
+                                               Or '%(Filename)' == 'mParticleRoktBinding'" />
+        </ItemGroup>
+
+        <Message Importance="high"
+                 Text="mParticle.Maui.Kits.Rokt.Payments: removed transitive mParticleBinding.framework and mParticleRoktBinding.framework from app bundle (kept only mParticleRoktPaymentsBinding.framework)." />
+    </Target>
+
+</Project>

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/mParticle.Maui.Kits.Rokt.Payments.csproj
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/mParticle.Maui.Kits.Rokt.Payments.csproj
@@ -1,0 +1,80 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
+        <UseMaui>true</UseMaui>
+        <SingleProject>true</SingleProject>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsBindingProject>true</IsBindingProject>
+        <NoBindingEmbedding>true</NoBindingEmbedding>
+
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+        <RootNamespace>mParticle.MAUI.Rokt.Payments</RootNamespace>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <PackageId>mParticle.Maui.Kits.Rokt.Payments</PackageId>
+        <Version>4.1.1</Version>
+        <Authors>mParticle</Authors>
+        <Description>Optional Apple Pay / Stripe payment extension for the mParticle Rokt MAUI kit. Enables payment flows in Rokt Shoppable Ads.</Description>
+        <Copyright>Copyright (c) mParticle Inc. 2024</Copyright>
+        <PackageProjectUrl>https://www.mparticle.com/</PackageProjectUrl>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="LICENSE" Pack="true" PackagePath=""/>
+        <None Include="README.md" Pack="true" PackagePath=""/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
+        <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
+        <PackageReference Include="CommunityToolkit.Maui.NativeLibraryInterop.BuildTasks" Version="0.0.1-pre1" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../MParticle.Maui.Rokt/mParticle.Maui.Kits.Rokt.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="$(TargetFramework.Contains('ios'))">
+        <ObjcBindingApiDefinition Include="macios/mParticleRoktPaymentsBinding.MaciOS.Binding/ApiDefinitions.cs" />
+        <XcodeProject Include="macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.xcodeproj">
+            <SchemeName>mParticleRoktPaymentsBinding</SchemeName>
+        </XcodeProject>
+        <Folder Include="macios\native\mParticleRoktPaymentsSPM\" />
+    </ItemGroup>
+
+    <!-- iOS -->
+    <ItemGroup Condition="$(TargetFramework.Contains('ios')) != true">
+        <Compile Remove="**\ios\**\*.cs" />
+        <Compile Remove="macios\native\mParticleRoktPaymentsBinding\bin\**" />
+        <None Remove="macios\native\mParticleRoktPaymentsBinding\bin\**" />
+        <Compile Remove="macios\mParticleRoktPaymentsBinding.MaciOS.Binding\ApiDefinitions.cs" />
+    </ItemGroup>
+
+    <!-- Copy mParticleRoktPaymentsBindingiOS.xcframework to resources after Build -->
+    <Target Name="CopyPaymentsFramework" AfterTargets="Build" Condition="$(TargetFramework.Contains('ios'))">
+        <PropertyGroup>
+            <_PaymentsResourcesPath>$(OutputPath)mParticle.Maui.Kits.Rokt.Payments.resources</_PaymentsResourcesPath>
+            <_PaymentsBindingXcFrameworkPath>$(MSBuildProjectDirectory)/obj/$(Configuration)/$(TargetFramework)/xcode/mParticleRoktPaymentsBinding-*/xcframeworks/mParticleRoktPaymentsBindingiOS.xcframework</_PaymentsBindingXcFrameworkPath>
+        </PropertyGroup>
+        <MakeDir Directories="$(_PaymentsResourcesPath)" />
+        <Exec Command="cp -R $(_PaymentsBindingXcFrameworkPath) &quot;$(_PaymentsResourcesPath)/&quot;" ContinueOnError="true" />
+        <Copy
+            SourceFiles="$(MSBuildThisFileDirectory)manifest.template"
+            DestinationFiles="$(_PaymentsResourcesPath)/manifest"
+            Condition="Exists('$(_PaymentsResourcesPath)/mParticleRoktPaymentsBindingiOS.xcframework')"
+            SkipUnchangedFiles="true" />
+    </Target>
+
+    <!-- Clean mParticleRoktPaymentsBinding DerivedData from global Xcode cache during clean -->
+    <Target Name="CleanmParticleRoktPaymentsBindingDerivedData" BeforeTargets="Clean" Condition="$(TargetFramework.Contains('ios')) == true">
+        <Exec Command="rm -rf $(HOME)/Library/Developer/Xcode/DerivedData/mParticleRoktPaymentsBinding-*" ContinueOnError="true" />
+        <Message Text="Cleaned mParticleRoktPaymentsBinding DerivedData from $(HOME)/Library/Developer/Xcode/DerivedData" Importance="high" />
+    </Target>
+
+</Project>

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/mParticle.Maui.Kits.Rokt.Payments.csproj
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/mParticle.Maui.Kits.Rokt.Payments.csproj
@@ -28,6 +28,9 @@
     <ItemGroup>
         <None Include="LICENSE" Pack="true" PackagePath=""/>
         <None Include="README.md" Pack="true" PackagePath=""/>
+        <None Include="build/mParticle.Maui.Kits.Rokt.Payments.targets"
+              Pack="true"
+              PackagePath="build/mParticle.Maui.Kits.Rokt.Payments.targets" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/mParticleRoktPaymentsBinding.MaciOS.Binding/ApiDefinitions.cs
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/mParticleRoktPaymentsBinding.MaciOS.Binding/ApiDefinitions.cs
@@ -1,0 +1,28 @@
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace mParticle.MAUI.Rokt.Payments.iOSBinding
+{
+    // @interface MPRoktStripePaymentExtension : NSObject
+    [BaseType(typeof(NSObject))]
+    [DisableDefaultCtor]
+    interface MPRoktStripePaymentExtension
+    {
+        // +(id _Nullable)createWithApplePayMerchantId:(NSString * _Nonnull)applePayMerchantId countryCode:(NSString * _Nonnull)countryCode;
+        [Static]
+        [Export("createWithApplePayMerchantId:countryCode:")]
+        [return: NullAllowed]
+        NSObject Create(string applePayMerchantId, string countryCode);
+    }
+
+    // @interface MPRokt (Payments)
+    [Category]
+    [BaseType(typeof(global::mParticle.MAUI.iOSBinding.MPRokt))]
+    interface MPRokt_Payments
+    {
+        // -(void)registerPaymentExtension:(id<RoktPaymentExtension> _Nonnull)paymentExtension;
+        [Export("registerPaymentExtension:")]
+        void RegisterPaymentExtension(NSObject paymentExtension);
+    }
+}

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/mParticleRoktPaymentsBinding.MaciOS.Binding/ApiDefinitions.cs
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/mParticleRoktPaymentsBinding.MaciOS.Binding/ApiDefinitions.cs
@@ -1,24 +1,23 @@
 using System;
 using Foundation;
 using ObjCRuntime;
+using mParticle.MAUI.iOSBinding;
 
 namespace mParticle.MAUI.Rokt.Payments.iOSBinding
 {
-    // @interface MPRoktStripePaymentExtension : NSObject
+    // @interface MPRoktStripePaymentExtension : NSObject <RoktPaymentExtension>
     [BaseType(typeof(NSObject))]
     [DisableDefaultCtor]
     interface MPRoktStripePaymentExtension
     {
-        // +(id _Nullable)createWithApplePayMerchantId:(NSString * _Nonnull)applePayMerchantId countryCode:(NSString * _Nonnull)countryCode;
-        [Static]
-        [Export("createWithApplePayMerchantId:countryCode:")]
-        [return: NullAllowed]
-        NSObject Create(string applePayMerchantId, string countryCode);
+        // -(instancetype _Nullable)initWithApplePayMerchantId:(NSString * _Nonnull)applePayMerchantId countryCode:(NSString * _Nonnull)countryCode;
+        [Export("initWithApplePayMerchantId:countryCode:")]
+        NativeHandle Constructor(string applePayMerchantId, string countryCode);
     }
 
     // @interface MPRokt (Payments)
     [Category]
-    [BaseType(typeof(global::mParticle.MAUI.iOSBinding.MPRokt))]
+    [BaseType(typeof(MPRokt))]
     interface MPRokt_Payments
     {
         // -(void)registerPaymentExtension:(id<RoktPaymentExtension> _Nonnull)paymentExtension;
@@ -26,3 +25,4 @@ namespace mParticle.MAUI.Rokt.Payments.iOSBinding
         void RegisterPaymentExtension(NSObject paymentExtension);
     }
 }
+ 

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.xcodeproj/project.pbxproj
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.xcodeproj/project.pbxproj
@@ -182,7 +182,7 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				PRODUCT_BUNDLE_IDENTIFIER = MParticle.MauiMParticleRokt;
+				PRODUCT_BUNDLE_IDENTIFIER = MParticle.MauiMParticleRoktPayments;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
@@ -227,7 +227,7 @@
 				MARKETING_VERSION = 1.0;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
-				PRODUCT_BUNDLE_IDENTIFIER = MParticle.MauiMParticleRokt;
+				PRODUCT_BUNDLE_IDENTIFIER = MParticle.MauiMParticleRoktPayments;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.xcodeproj/project.pbxproj
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.xcodeproj/project.pbxproj
@@ -1,0 +1,404 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		F686674E2CF5F689004A5DB7 /* mParticleRoktPaymentsSPM in Frameworks */ = {isa = PBXBuildFile; productRef = F686674D2CF5F689004A5DB6 /* mParticleRoktPaymentsSPM */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		F68667372CF5E16A004A5DB2 /* mParticleRoktPaymentsBinding.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticleRoktPaymentsBinding.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		F68667392CF5E16A004A5DB2 /* mParticleRoktPaymentsBinding */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = mParticleRoktPaymentsBinding;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F68667342CF5E16A004A5DB2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F686674E2CF5F689004A5DB7 /* mParticleRoktPaymentsSPM in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		F686672D2CF5E16A004A5DB2 = {
+			isa = PBXGroup;
+			children = (
+				F68667392CF5E16A004A5DB2 /* mParticleRoktPaymentsBinding */,
+				F68667492CF5F689004A5DB2 /* Frameworks */,
+				F68667382CF5E16A004A5DB2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		F68667382CF5E16A004A5DB2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F68667372CF5E16A004A5DB2 /* mParticleRoktPaymentsBinding.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F68667492CF5F689004A5DB2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		F68667322CF5E16A004A5DB2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		F68667362CF5E16A004A5DB2 /* mParticleRoktPaymentsBinding */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F686673D2CF5E16A004A5DB2 /* Build configuration list for PBXNativeTarget "mParticleRoktPaymentsBinding" */;
+			buildPhases = (
+				F68667322CF5E16A004A5DB2 /* Headers */,
+				F68667332CF5E16A004A5DB2 /* Sources */,
+				F68667342CF5E16A004A5DB2 /* Frameworks */,
+				F68667352CF5E16A004A5DB2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F68667392CF5E16A004A5DB2 /* mParticleRoktPaymentsBinding */,
+			);
+			name = mParticleRoktPaymentsBinding;
+			packageProductDependencies = (
+			);
+			productName = MauiMParticle;
+			productReference = F68667372CF5E16A004A5DB2 /* mParticleRoktPaymentsBinding.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F686672E2CF5E16A004A5DB2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastUpgradeCheck = 1610;
+				TargetAttributes = {
+					F68667362CF5E16A004A5DB2 = {
+						CreatedOnToolsVersion = 16.1;
+						LastSwiftMigration = 1610;
+					};
+				};
+			};
+			buildConfigurationList = F68667312CF5E16A004A5DB2 /* Build configuration list for PBXProject "mParticleRoktPaymentsBinding" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F686672D2CF5E16A004A5DB2;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				F686674C2CF5F689004A5DB5 /* XCLocalSwiftPackageReference "mParticleRoktPaymentsSPM" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = F68667382CF5E16A004A5DB2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F68667362CF5E16A004A5DB2 /* mParticleRoktPaymentsBinding */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F68667352CF5E16A004A5DB2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F68667332CF5E16A004A5DB2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		F686673E2CF5E16A004A5DB2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				FRAMEWORK_SEARCH_PATHS = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.7;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = MParticle.MauiMParticleRokt;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				XROS_DEPLOYMENT_TARGET = 2.1;
+			};
+			name = Debug;
+		};
+		F686673F2CF5E16A004A5DB2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
+				FRAMEWORK_SEARCH_PATHS = "";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.7;
+				MARKETING_VERSION = 1.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
+				PRODUCT_BUNDLE_IDENTIFIER = MParticle.MauiMParticleRokt;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				XROS_DEPLOYMENT_TARGET = 2.1;
+			};
+			name = Release;
+		};
+		F68667402CF5E16A004A5DB2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		F68667412CF5E16A004A5DB2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F68667312CF5E16A004A5DB2 /* Build configuration list for PBXProject "mParticleRoktPaymentsBinding" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F68667402CF5E16A004A5DB2 /* Debug */,
+				F68667412CF5E16A004A5DB2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F686673D2CF5E16A004A5DB2 /* Build configuration list for PBXNativeTarget "mParticleRoktPaymentsBinding" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F686673E2CF5E16A004A5DB2 /* Debug */,
+				F686673F2CF5E16A004A5DB2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+
+/* Begin XCLocalSwiftPackageReference section */
+		F686674C2CF5F689004A5DB5 /* XCLocalSwiftPackageReference "mParticleRoktPaymentsSPM" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../mParticleRoktPaymentsSPM;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F686674D2CF5F689004A5DB6 /* mParticleRoktPaymentsSPM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F686674C2CF5F689004A5DB5 /* XCLocalSwiftPackageReference "mParticleRoktPaymentsSPM" */;
+			productName = mParticleRoktPaymentsSPM;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = F686672E2CF5E16A004A5DB2 /* Project object */;
+}

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.xcodeproj/xcshareddata/xcschemes/mParticleRoktPaymentsBinding.xcscheme
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.xcodeproj/xcshareddata/xcschemes/mParticleRoktPaymentsBinding.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F68667362CF5E16A004A5DB2"
+               BuildableName = "mParticleRoktPaymentsBinding.framework"
+               BlueprintName = "mParticleRoktPaymentsBinding"
+               ReferencedContainer = "container:mParticleRoktPaymentsBinding.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F68667362CF5E16A004A5DB2"
+            BuildableName = "mParticleRoktPaymentsBinding.framework"
+            BlueprintName = "mParticleRoktPaymentsBinding"
+            ReferencedContainer = "container:mParticleRoktPaymentsBinding.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.h
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding/mParticleRoktPaymentsBinding.h
@@ -1,0 +1,24 @@
+//
+//  mParticleRoktPaymentsBinding.h
+//  mParticleRoktPaymentsBinding
+//
+//  Copyright 2020 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for mParticleRoktPaymentsBinding.
+FOUNDATION_EXPORT double mParticleRoktPaymentsBindingVersionNumber;
+
+//! Project version string for mParticleRoktPaymentsBinding.
+FOUNDATION_EXPORT const unsigned char mParticleRoktPaymentsBindingVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <mParticleRoktPaymentsBinding/PublicHeader.h>
+
+

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Package.swift
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Package.swift
@@ -15,13 +15,17 @@ let package = Package(
             targets: ["mParticleRoktPaymentsSPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", exact: "0.1.2"),
+        .package(url: "https://github.com/mParticle/mparticle-apple-sdk", exact: "9.0.0"),
+        .package(url: "https://github.com/mparticle-integrations/mp-apple-integration-rokt.git", exact: "9.0.0"),
+        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", .upToNextMinor(from: "0.1.3")),
         .package(url: "https://github.com/ROKT/rokt-stripe-payment-extension-ios.git", exact: "0.1.2")
     ],
     targets: [
         .target(
             name: "mParticleRoktPaymentsSPM",
             dependencies: [
+                .product(name: "mParticle-Apple-SDK", package: "mparticle-apple-sdk"),
+                .product(name: "mParticle-Rokt", package: "mp-apple-integration-rokt"),
                 .product(name: "RoktContracts", package: "rokt-contracts-apple"),
                 .product(name: "RoktStripePaymentExtension", package: "rokt-stripe-payment-extension-ios")
             ]

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Package.swift
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "mParticleRoktPaymentsSPM",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(
+            name: "mParticleRoktPaymentsSPM",
+            type: .static,
+            targets: ["mParticleRoktPaymentsSPM"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/ROKT/rokt-contracts-apple.git", exact: "0.1.2"),
+        .package(url: "https://github.com/ROKT/rokt-stripe-payment-extension-ios.git", exact: "0.1.2")
+    ],
+    targets: [
+        .target(
+            name: "mParticleRoktPaymentsSPM",
+            dependencies: [
+                .product(name: "RoktContracts", package: "rokt-contracts-apple"),
+                .product(name: "RoktStripePaymentExtension", package: "rokt-stripe-payment-extension-ios")
+            ]
+        )
+    ]
+)

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Sources/mParticleRoktPaymentsSPM/MPRoktStripePaymentExtension.swift
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Sources/mParticleRoktPaymentsSPM/MPRoktStripePaymentExtension.swift
@@ -1,0 +1,39 @@
+//
+//  MPRoktStripePaymentExtension.swift
+//  mParticleRoktPaymentsSPM
+//
+//  Copyright 2024 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+
+import Foundation
+import RoktContracts
+import RoktStripePaymentExtension
+
+/// Objective-C shim exposing a factory for `RoktStripePaymentExtension`
+/// so the Xamarin.iOS binding generator (which only sees ObjC) can
+/// instantiate the pure-Swift extension and hand it back to C#.
+///
+/// The returned object conforms to the `RoktPaymentExtension` protocol
+/// and is meant to be passed to `-[MPRokt registerPaymentExtension:]`.
+@objc(MPRoktStripePaymentExtension)
+public final class MPRoktStripePaymentExtension: NSObject {
+
+    /// Factory method. Returns the payment extension as an opaque object
+    /// so C# can forward it to `MPRokt.registerPaymentExtension:` without
+    /// knowing about the Swift-only `RoktPaymentExtension` protocol.
+    ///
+    /// - Parameters:
+    ///   - applePayMerchantId: Apple Pay merchant identifier
+    ///     (e.g. `merchant.com.yourapp.rokt`).
+    ///   - countryCode: ISO country code, defaults to `"US"`.
+    /// - Returns: The payment extension instance, or `nil` if initialization fails.
+    @objc(createWithApplePayMerchantId:countryCode:)
+    public static func create(applePayMerchantId: String,
+                              countryCode: String) -> AnyObject? {
+        return RoktStripePaymentExtension(applePayMerchantId: applePayMerchantId,
+                                          countryCode: countryCode)
+    }
+}

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Sources/mParticleRoktPaymentsSPM/MPRoktStripePaymentExtension.swift
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Sources/mParticleRoktPaymentsSPM/MPRoktStripePaymentExtension.swift
@@ -11,29 +11,67 @@
 import Foundation
 import RoktContracts
 import RoktStripePaymentExtension
+import UIKit
 
-/// Objective-C shim exposing a factory for `RoktStripePaymentExtension`
-/// so the Xamarin.iOS binding generator (which only sees ObjC) can
-/// instantiate the pure-Swift extension and hand it back to C#.
+/// `@objc NSObject` wrapper around the pure-Swift
+/// `RoktStripePaymentExtension`, conforming to the `@objc(RoktPaymentExtension)`
+/// protocol (`PaymentExtension`).
 ///
-/// The returned object conforms to the `RoktPaymentExtension` protocol
-/// and is meant to be passed to `-[MPRokt registerPaymentExtension:]`.
+/// The wrapper exists so a concrete instance can safely cross the Xamarin.iOS
+/// bridge (Xamarin can only marshal `NSObject`-derived types). All protocol
+/// methods are forwarded to the underlying pure-Swift implementation.
 @objc(MPRoktStripePaymentExtension)
-public final class MPRoktStripePaymentExtension: NSObject {
+public final class MPRoktStripePaymentExtension: NSObject, PaymentExtension {
 
-    /// Factory method. Returns the payment extension as an opaque object
-    /// so C# can forward it to `MPRokt.registerPaymentExtension:` without
-    /// knowing about the Swift-only `RoktPaymentExtension` protocol.
+    private let inner: RoktStripePaymentExtension
+
+    /// Creates a new Stripe payment extension.
     ///
     /// - Parameters:
-    ///   - applePayMerchantId: Apple Pay merchant identifier
-    ///     (e.g. `merchant.com.yourapp.rokt`).
-    ///   - countryCode: ISO country code, defaults to `"US"`.
-    /// - Returns: The payment extension instance, or `nil` if initialization fails.
-    @objc(createWithApplePayMerchantId:countryCode:)
-    public static func create(applePayMerchantId: String,
-                              countryCode: String) -> AnyObject? {
-        return RoktStripePaymentExtension(applePayMerchantId: applePayMerchantId,
-                                          countryCode: countryCode)
+    ///   - applePayMerchantId: Apple Pay merchant identifier (must be non-empty).
+    ///   - countryCode: ISO 3166-1 alpha-2 country code (e.g. `"US"`).
+    @objc(initWithApplePayMerchantId:countryCode:)
+    public init?(applePayMerchantId: String, countryCode: String) {
+        guard let inner = RoktStripePaymentExtension(
+            applePayMerchantId: applePayMerchantId,
+            countryCode: countryCode
+        ) else {
+            return nil
+        }
+        self.inner = inner
+        super.init()
+    }
+
+    // MARK: - PaymentExtension
+
+    public var id: String { inner.id }
+    public var extensionDescription: String { inner.extensionDescription }
+    public var supportedMethods: [String] { inner.supportedMethods }
+
+    public func onRegister(parameters: [String: String]) -> Bool {
+        inner.onRegister(parameters: parameters)
+    }
+
+    public func onUnregister() {
+        inner.onUnregister()
+    }
+
+    public func presentPaymentSheet(
+        item: PaymentItem,
+        method: PaymentMethodType,
+        from viewController: UIViewController,
+        preparePayment: @escaping (
+            _ address: ContactAddress,
+            _ completion: @escaping (PaymentPreparation?, Error?) -> Void
+        ) -> Void,
+        completion: @escaping (PaymentSheetResult) -> Void
+    ) {
+        inner.presentPaymentSheet(
+            item: item,
+            method: method,
+            from: viewController,
+            preparePayment: preparePayment,
+            completion: completion
+        )
     }
 }

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Sources/mParticleRoktPaymentsSPM/mParticleRoktPaymentsSPM.swift
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Sources/mParticleRoktPaymentsSPM/mParticleRoktPaymentsSPM.swift
@@ -1,0 +1,23 @@
+//
+//  mParticleRoktPaymentsSPM.swift
+//  mParticleRoktPaymentsSPM
+//
+//  Copyright 2024 Rokt Pte Ltd
+//
+//  Licensed under the Rokt Software Development Kit (SDK) Terms of Use
+//  Version 2.0 (the "License");
+//
+//  You may not use this file except in compliance with the License.
+//
+//  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
+
+import Foundation
+@_exported import RoktContracts
+@_exported import RoktStripePaymentExtension
+
+/// SPM wrapper for the Rokt payment extension dependencies.
+/// Re-exports RoktContracts and RoktStripePaymentExtension so that the
+/// Xcode binding project can consume them through a single module.
+public struct MParticleRoktPaymentsSPM {
+    // Umbrella module — intentionally empty.
+}

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Sources/mParticleRoktPaymentsSPM/mParticleRoktPaymentsSPM.swift
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM/Sources/mParticleRoktPaymentsSPM/mParticleRoktPaymentsSPM.swift
@@ -12,12 +12,27 @@
 //  You may obtain a copy of the License at https://rokt.com/sdk-license-2-0/
 
 import Foundation
+@_exported import mParticle_Apple_SDK
+@_exported import mParticle_Rokt_Swift
 @_exported import RoktContracts
 @_exported import RoktStripePaymentExtension
 
-/// SPM wrapper for the Rokt payment extension dependencies.
-/// Re-exports RoktContracts and RoktStripePaymentExtension so that the
-/// Xcode binding project can consume them through a single module.
-public struct MParticleRoktPaymentsSPM {
+/// SPM wrapper for the Rokt Payments kit.
+///
+/// Re-exports the full native stack needed at runtime so that a single
+/// xcframework produced from this package contains every symbol the
+/// managed Xamarin.iOS bindings reference:
+///
+/// - `mParticle-Apple-SDK` — core mParticle SDK (MParticle, MPEvent,
+///   MPKitExecStatus, MPForwardRecord, ...).
+/// - `mParticle-Rokt` — Rokt kit implementation (MPKitRokt, MPRokt).
+/// - `RoktContracts` — shared Rokt payment/DCUI contracts.
+/// - `RoktStripePaymentExtension` — Stripe / Apple Pay payment extension.
+///
+/// Bundling everything under one umbrella lets the consuming application
+/// ship a single xcframework (while still letting NuGet resolve the
+/// `MParticle.Maui` and `MParticle.Maui.Kits.Rokt` C# bindings), avoiding
+/// duplicate Objective-C class definitions at runtime.
+public enum MParticleRoktPaymentsSPM {
     // Umbrella module — intentionally empty.
 }

--- a/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/manifest.template
+++ b/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/manifest.template
@@ -1,0 +1,6 @@
+<BindingAssembly>
+  <NativeReference Name="mParticleRoktPaymentsBindingiOS.xcframework">
+    <Kind>Framework</Kind>
+    <SmartLink>false</SmartLink>
+  </NativeReference>
+</BindingAssembly>

--- a/Sdk/MParticle.Maui.Sdk/MParticle.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.cs
@@ -331,6 +331,20 @@ public class RoktApiWrapper : RoktApi
 
         _roktInstance.SelectPlacements(identifier, nsAttributes, nsEmbeddedViews, nsConfig, enhancedCallbacks);
     }
+
+    public override void SelectShoppableAds(
+        string identifier,
+        Dictionary<string, string> attributes = null,
+        RoktConfig config = null,
+        RoktEventCallback callbacks = null)
+    {
+        var nsAttributes = Utils.ConvertToNSDictionary<NSString, NSString>(attributes)
+            ?? new NSDictionary<NSString, NSString>();
+        var nsConfig = Utils.ConvertToMpRoktConfig(config);
+        var enhancedCallbacks = Utils.ConvertToMpRoktEventCallback(callbacks);
+
+        _roktInstance.SelectShoppableAds(identifier, nsAttributes, nsConfig, enhancedCallbacks);
+    }
 }
 
 public class RoktEmbeddedViewHandler : ViewHandler<RoktEmbeddedView, iOSBinding.RoktEmbeddedView>
@@ -607,6 +621,17 @@ public class RoktApiWrapper : RoktApi
             throw new InvalidOperationException("Rokt instance is not available. Make sure mParticle is properly initialized.");
         }
     }
+
+    public override void SelectShoppableAds(
+        string identifier,
+        Dictionary<string, string> attributes = null,
+        RoktConfig config = null,
+        RoktEventCallback callbacks = null)
+    {
+        // Parity with Flutter/React Native: Android exposes the API but does not
+        // have native Shoppable Ads support yet. Keep a no-op bridge with a warning log.
+        Console.WriteLine("[mParticle MAUI SDK] SelectShoppableAds is not yet supported on Android.");
+    }
 }
 
 public class RoktEmbeddedViewHandler : ViewHandler<RoktEmbeddedView, global::Android.Views.View>
@@ -633,6 +658,15 @@ public class NoOpRoktApiWrapper : RoktApi
         string identifier,
         Dictionary<string, string> attributes = null,
         Dictionary<string, RoktEmbeddedView> embeddedViews = null,
+        RoktConfig config = null,
+        RoktEventCallback callbacks = null)
+    {
+        Console.WriteLine(MParticleSDK.SdkNotInitializedWarning);
+    }
+
+    public override void SelectShoppableAds(
+        string identifier,
+        Dictionary<string, string> attributes = null,
         RoktConfig config = null,
         RoktEventCallback callbacks = null)
     {

--- a/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
@@ -454,6 +454,24 @@ public abstract class RoktApi
         Dictionary<string, RoktEmbeddedView> embeddedViews = null,
         RoktConfig config = null,
         RoktEventCallback callbacks = null);
+
+    /// <summary>
+    /// Displays a Shoppable Ads overlay placement.
+    /// </summary>
+    /// <remarks>
+    /// This method is currently implemented only on iOS (requires iOS 15+ and
+    /// the Rokt kit to have a payment extension registered natively).
+    /// Android keeps a no-op bridge for API compatibility until native support lands.
+    /// </remarks>
+    /// <param name="identifier">The view name / placement identifier.</param>
+    /// <param name="attributes">Optional attributes for targeting.</param>
+    /// <param name="config">Optional display configuration (color mode, caching).</param>
+    /// <param name="callbacks">Optional event callbacks.</param>
+    public abstract void SelectShoppableAds(
+        string identifier,
+        Dictionary<string, string> attributes = null,
+        RoktConfig config = null,
+        RoktEventCallback callbacks = null);
 }
 
 public abstract class MParticleSDK

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
@@ -1194,6 +1194,17 @@ namespace mParticle.MAUI.iOSBinding {
         [Export("purchaseFinalized:catalogItemId:success:")]
         void PurchaseFinalized(string identifier, string catalogItemId, bool success);
 
+        // -(void)selectShoppableAds:(NSString * _Nonnull)identifier attributes:(NSDictionary<NSString *, NSString *> * _Nonnull)attributes;
+        [Export("selectShoppableAds:attributes:")]
+        void SelectShoppableAds(string identifier, NSDictionary<NSString, NSString> attributes);
+
+        // -(void)selectShoppableAds:(NSString * _Nonnull)identifier attributes:(NSDictionary<NSString *, NSString *> * _Nonnull)attributes config:(RoktConfig * _Nullable)config onEvent:(void (^ _Nullable)(RoktEvent * _Nonnull))onEvent;
+        [Export("selectShoppableAds:attributes:config:onEvent:")]
+        void SelectShoppableAds(string identifier,
+            NSDictionary<NSString, NSString> attributes,
+            [NullAllowed] RoktConfig config,
+            [NullAllowed] Action<RoktEvent> onEvent);
+
         // -(void)events:(NSString * _Nonnull)identifier onEvent:(void (^ _Nullable)(RoktEvent * _Nonnull))onEvent;
         [Export("events:onEvent:")]
         void Events(string identifier, [NullAllowed] Action<RoktEvent> onEvent);

--- a/scripts/verify-ios-release.sh
+++ b/scripts/verify-ios-release.sh
@@ -40,6 +40,7 @@ fi
 
 SDK_PATH="${SDK_ROOT}/Sdk/MParticle.Maui.Sdk"
 ROKT_KIT_PATH="${SDK_ROOT}/Kits/rokt/Sdk/MParticle.Maui.Rokt"
+PAYMENTS_KIT_PATH="${SDK_ROOT}/Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -73,6 +74,14 @@ log "Building mParticleRoktBinding for iphoneos and iphonesimulator..."
 xcodebuild -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding -configuration Release -sdk iphoneos build -quiet
 xcodebuild -project mParticleRoktBinding.xcodeproj -scheme mParticleRoktBinding -configuration Release -sdk iphonesimulator build -quiet
 
+log "Resolving SPM for mParticleRoktPaymentsBinding..."
+cd "${PAYMENTS_KIT_PATH}/macios/native/mParticleRoktPaymentsBinding"
+xcodebuild -resolvePackageDependencies -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding -quiet
+
+log "Building mParticleRoktPaymentsBinding for iphoneos and iphonesimulator..."
+xcodebuild -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding -configuration Release -sdk iphoneos build -quiet
+xcodebuild -project mParticleRoktPaymentsBinding.xcodeproj -scheme mParticleRoktPaymentsBinding -configuration Release -sdk iphonesimulator build -quiet
+
 # --- 2. Pack SDK to local feed ---
 log "Packing SDK to ${LOCAL_NUGET} (version ${VERSION})"
 cd "${SDK_ROOT}"
@@ -80,6 +89,7 @@ mkdir -p "${LOCAL_NUGET}"
 
 dotnet pack "${SDK_PATH}/MParticle.Maui.Sdk.csproj" -c Release -o "${LOCAL_NUGET}" -p:Version="${VERSION}"
 dotnet pack "${ROKT_KIT_PATH}/mParticle.Maui.Kits.Rokt.csproj" -c Release -o "${LOCAL_NUGET}" -p:Version="${VERSION}"
+dotnet pack "${PAYMENTS_KIT_PATH}/mParticle.Maui.Kits.Rokt.Payments.csproj" -c Release -o "${LOCAL_NUGET}" -p:Version="${VERSION}"
 
 # shellcheck disable=SC2312
 PKG_COUNT=$(find "${LOCAL_NUGET}" -maxdepth 1 -name "*.nupkg" -print 2>/dev/null | wc -l | tr -d ' ')


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Background

Shoppable Ads flows in the Rokt kit require an Apple Pay / Stripe payment
extension that is not part of the base integration. This PR adds a new
optional NuGet package, `mParticle.Maui.Kits.Rokt.Payments`, that plugs
the Stripe payment extension into the Rokt kit without changing the core
SDK surface or forcing Stripe on consumers that do not need it.

## What Has Changed

- New `mParticle.Maui.Kits.Rokt.Payments` NuGet package with a public
  `RoktStripePaymentExtension.Register(merchantId, countryCode)` API and
  an iOS-only `[Category]` binding that adds `RegisterPaymentExtension`
  to `MPRokt` only when the Payments kit is referenced.
- Core SDK gains a `SelectShoppableAds` Rokt API (plus a sample button)
  so apps can launch the Shoppable Ads flow once the payment extension
  is registered.
- Payments kit ships a single "fat" xcframework (core SDK + Rokt kit +
  Rokt Contracts + Stripe payment extension, via `@_exported import`)
  and a NuGet `build/*.targets` file that strips the now-redundant
  transitive xcframeworks from consumer apps, eliminating duplicate
  Objective-C class crashes at runtime.
- Android target is a no-op for this kit (iOS-only feature).
- CI/release pipelines (`pull-request.yml`, `release-from-main.yml`,
  `draft-release-publish.yml`, `scripts/verify-ios-release.sh`) now
  build, pack, publish and version-bump the Payments kit alongside the
  SDK and Rokt kit, using the shared VERSION file.

## Screenshots/Video

- {Include any screenshots or video demonstrating the new feature or fix, if applicable}

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes

- The Payments kit is additive and opt-in: consumers that do not add
  the NuGet see no change in behavior or payload size.
- A matching `Entitlements.plist` with the Apple Pay capability and a
  valid merchant identifier must be configured in the consumer app for
  the Apple Pay flow to work.