### PR TITLE
feat: align Rokt event subscriptions with cross-platform API

### DIFF
--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.3
+          xcode-version: 26.4
 
       - name: Install .NET MAUI
         run: dotnet workload install maui

--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -64,10 +64,10 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.4
+          xcode-version: 26.3
 
       - name: Install .NET MAUI
-        run: dotnet workload install maui
+        run: dotnet workload install maui --skip-manifest-update
 
       - name: Get current version
         id: version-file

--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.0
+          xcode-version: "26.0"
 
       - name: Install .NET MAUI
         run: dotnet workload install maui --skip-manifest-update

--- a/.github/workflows/draft-release-publish.yml
+++ b/.github/workflows/draft-release-publish.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.3
+          xcode-version: 26.0
 
       - name: Install .NET MAUI
         run: dotnet workload install maui --skip-manifest-update

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.4
+          xcode-version: 26.3
 
       - name: Install .NET MAUI
-        run: dotnet workload install maui
+        run: dotnet workload install maui --skip-manifest-update
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.0
+          xcode-version: "26.0"
 
       - name: Install .NET MAUI
         run: dotnet workload install maui --skip-manifest-update

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.3
+          xcode-version: 26.0
 
       - name: Install .NET MAUI
         run: dotnet workload install maui --skip-manifest-update

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.3
+          xcode-version: 26.4
 
       - name: Install .NET MAUI
         run: dotnet workload install maui

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -61,10 +61,10 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.4
+          xcode-version: 26.3
 
       - name: Install .NET MAUI
-        run: dotnet workload install maui
+        run: dotnet workload install maui --skip-manifest-update
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.3
+          xcode-version: 26.4
 
       - name: Install .NET MAUI
         run: dotnet workload install maui

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.0
+          xcode-version: "26.0"
 
       - name: Install .NET MAUI
         run: dotnet workload install maui --skip-manifest-update

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup XCode
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 26.3
+          xcode-version: 26.0
 
       - name: Install .NET MAUI
         run: dotnet workload install maui --skip-manifest-update

--- a/Kits/rokt/SampleApp/MainPage.xaml.cs
+++ b/Kits/rokt/SampleApp/MainPage.xaml.cs
@@ -7,6 +7,7 @@ namespace SampleApp;
 public partial class MainPage : ContentPage
 {
     private const string ConstantUserAttribute = "Test Attribute Key";
+    private readonly HashSet<string> _roktEventSubscriptions = new();
 
     public MainPage()
     {
@@ -256,6 +257,7 @@ public partial class MainPage : ContentPage
     {
         Console.WriteLine("Show Rokt Embedded Called");
         var mparticle = MParticle.Instance;
+        SubscribeToPlacementEvents("MSDKEmbeddedLayout", "embedded");
 
         var attributes = new Dictionary<string, string>
         {
@@ -265,15 +267,6 @@ public partial class MainPage : ContentPage
             ["billingzipcode"] = "07762",
             ["confirmationref"] = "54321",
             ["country"] = "US"
-        };
-
-        var callbacks = new RoktEventCallback
-        {
-            OnLoad = () => Console.WriteLine("Rokt placement loaded"),
-            OnUnLoad = (reason) => Console.WriteLine($"Rokt placement unloaded with reason: {reason}"),
-            OnShouldShowLoadingIndicator = () => Console.WriteLine("Should show loading indicator"),
-            OnShouldHideLoadingIndicator = () => Console.WriteLine("Should hide loading indicator"),
-            OnEmbeddedSizeChange = (identifier, size) => Console.WriteLine($"Embedded view '{identifier}' size changed to {size}")
         };
 
         mparticle.Rokt.SelectPlacements(
@@ -283,8 +276,7 @@ public partial class MainPage : ContentPage
             {
                 {"Location1", Location1}
             },
-            config: null,
-            callbacks: callbacks
+            config: null
         );
     }
 
@@ -292,6 +284,7 @@ public partial class MainPage : ContentPage
     {
         Console.WriteLine("Show Rokt Overlay Called");
         var mparticle = MParticle.Instance;
+        SubscribeToPlacementEvents("MSDKOverlayLayout", "overlay");
 
         var attributes = new Dictionary<string, string>
         {
@@ -303,15 +296,6 @@ public partial class MainPage : ContentPage
             ["country"] = "US"
         };
 
-        var callbacks = new RoktEventCallback
-        {
-            OnLoad = () => Console.WriteLine("Rokt placement loaded"),
-            OnUnLoad = (reason) => Console.WriteLine($"Rokt placement unloaded with reason: {reason}"),
-            OnShouldShowLoadingIndicator = () => Console.WriteLine("Should show loading indicator"),
-            OnShouldHideLoadingIndicator = () => Console.WriteLine("Should hide loading indicator"),
-            OnEmbeddedSizeChange = (identifier, size) => Console.WriteLine($"Embedded view '{identifier}' size changed to {size}")
-        };
-
         mparticle.Rokt.SelectPlacements(
             identifier: "MSDKOverlayLayout",
             attributes: attributes,
@@ -319,8 +303,7 @@ public partial class MainPage : ContentPage
             {
                 {"Location1", Location1}
             },
-            config: null,
-            callbacks: callbacks
+            config: null
         );
     }
 
@@ -328,6 +311,7 @@ public partial class MainPage : ContentPage
     {
         Console.WriteLine("Show Rokt Shoppable Ads Called");
         var mparticle = MParticle.Instance;
+        SubscribeToPlacementEvents("MSDKShoppableAdsLayout", "shoppable ads");
 
         var attributes = new Dictionary<string, string>
         {
@@ -352,22 +336,48 @@ public partial class MainPage : ContentPage
             ["email"] = "jenny.smith@example.com"
         };
 
-        var callbacks = new RoktEventCallback
-        {
-            OnLoad = () => Console.WriteLine("Rokt shoppable ads placement loaded"),
-            OnUnLoad = (reason) => Console.WriteLine($"Rokt shoppable ads placement unloaded with reason: {reason}"),
-            OnShouldShowLoadingIndicator = () => Console.WriteLine("Should show loading indicator"),
-            OnShouldHideLoadingIndicator = () => Console.WriteLine("Should hide loading indicator")
-        };
-
         // Note: on iOS this requires a payment extension to be registered natively
         // (see the Rokt kit docs for the one-time AppDelegate/Scene setup).
         // On Android this call is a no-op until native support lands.
         mparticle.Rokt.SelectShoppableAds(
             identifier: "MSDKShoppableAdsLayout",
             attributes: attributes,
-            config: null,
-            callbacks: callbacks
+            config: null
         );
+    }
+
+    private void SubscribeToPlacementEvents(string identifier, string placementName)
+    {
+        if (!_roktEventSubscriptions.Add(identifier))
+        {
+            return;
+        }
+
+        MParticle.Instance.Rokt.Events(identifier, roktEvent => LogRoktEvent(placementName, roktEvent));
+    }
+
+    private static void LogRoktEvent(string placementName, RoktEvent roktEvent)
+    {
+        switch (roktEvent)
+        {
+            case RoktPlacementReady e:
+                Console.WriteLine($"Rokt {placementName} placement loaded: {e.Identifier}");
+                break;
+            case RoktPlacementClosed e:
+                Console.WriteLine($"Rokt {placementName} placement unloaded: {e.Identifier}");
+                break;
+            case RoktShowLoadingIndicator:
+                Console.WriteLine($"Rokt {placementName}: should show loading indicator");
+                break;
+            case RoktHideLoadingIndicator:
+                Console.WriteLine($"Rokt {placementName}: should hide loading indicator");
+                break;
+            case RoktEmbeddedSizeChanged e:
+                Console.WriteLine($"Rokt {placementName} embedded view '{e.Identifier}' size changed to {e.UpdatedHeight}");
+                break;
+            default:
+                Console.WriteLine($"Rokt {placementName} event: {roktEvent.GetType().Name}");
+                break;
+        }
     }
 }

--- a/Kits/rokt/VerifyApp/MainPage.xaml.cs
+++ b/Kits/rokt/VerifyApp/MainPage.xaml.cs
@@ -6,6 +6,7 @@ namespace VerifyApp;
 public partial class MainPage : ContentPage
 {
     private const string ConstantUserAttribute = "Test Attribute Key";
+    private readonly HashSet<string> _roktEventSubscriptions = new();
 
     public MainPage()
     {
@@ -253,6 +254,7 @@ public partial class MainPage : ContentPage
     {
         Console.WriteLine("Show Rokt Embedded Called");
         var mparticle = MParticle.Instance;
+        SubscribeToPlacementEvents("MSDKEmbeddedLayout", "embedded");
 
         var attributes = new Dictionary<string, string>
         {
@@ -262,15 +264,6 @@ public partial class MainPage : ContentPage
             ["billingzipcode"] = "07762",
             ["confirmationref"] = "54321",
             ["country"] = "US"
-        };
-
-        var callbacks = new RoktEventCallback
-        {
-            OnLoad = () => Console.WriteLine("Rokt placement loaded"),
-            OnUnLoad = (reason) => Console.WriteLine($"Rokt placement unloaded with reason: {reason}"),
-            OnShouldShowLoadingIndicator = () => Console.WriteLine("Should show loading indicator"),
-            OnShouldHideLoadingIndicator = () => Console.WriteLine("Should hide loading indicator"),
-            OnEmbeddedSizeChange = (identifier, size) => Console.WriteLine($"Embedded view '{identifier}' size changed to {size}")
         };
 
         mparticle.Rokt.SelectPlacements(
@@ -280,8 +273,7 @@ public partial class MainPage : ContentPage
             {
                 {"Location1", Location1}
             },
-            config: null,
-            callbacks: callbacks
+            config: null
         );
     }
 
@@ -289,6 +281,7 @@ public partial class MainPage : ContentPage
     {
         Console.WriteLine("Show Rokt Overlay Called");
         var mparticle = MParticle.Instance;
+        SubscribeToPlacementEvents("MSDKOverlayLayout", "overlay");
 
         var attributes = new Dictionary<string, string>
         {
@@ -300,15 +293,6 @@ public partial class MainPage : ContentPage
             ["country"] = "US"
         };
 
-        var callbacks = new RoktEventCallback
-        {
-            OnLoad = () => Console.WriteLine("Rokt placement loaded"),
-            OnUnLoad = (reason) => Console.WriteLine($"Rokt placement unloaded with reason: {reason}"),
-            OnShouldShowLoadingIndicator = () => Console.WriteLine("Should show loading indicator"),
-            OnShouldHideLoadingIndicator = () => Console.WriteLine("Should hide loading indicator"),
-            OnEmbeddedSizeChange = (identifier, size) => Console.WriteLine($"Embedded view '{identifier}' size changed to {size}")
-        };
-
         mparticle.Rokt.SelectPlacements(
             identifier: "MSDKOverlayLayout",
             attributes: attributes,
@@ -316,8 +300,42 @@ public partial class MainPage : ContentPage
             {
                 {"Location1", Location1}
             },
-            config: null,
-            callbacks: callbacks
+            config: null
         );
+    }
+
+    private void SubscribeToPlacementEvents(string identifier, string placementName)
+    {
+        if (!_roktEventSubscriptions.Add(identifier))
+        {
+            return;
+        }
+
+        MParticle.Instance.Rokt.Events(identifier, roktEvent => LogRoktEvent(placementName, roktEvent));
+    }
+
+    private static void LogRoktEvent(string placementName, RoktEvent roktEvent)
+    {
+        switch (roktEvent)
+        {
+            case RoktPlacementReady e:
+                Console.WriteLine($"Rokt {placementName} placement loaded: {e.Identifier}");
+                break;
+            case RoktPlacementClosed e:
+                Console.WriteLine($"Rokt {placementName} placement unloaded: {e.Identifier}");
+                break;
+            case RoktShowLoadingIndicator:
+                Console.WriteLine($"Rokt {placementName}: should show loading indicator");
+                break;
+            case RoktHideLoadingIndicator:
+                Console.WriteLine($"Rokt {placementName}: should hide loading indicator");
+                break;
+            case RoktEmbeddedSizeChanged e:
+                Console.WriteLine($"Rokt {placementName} embedded view '{e.Identifier}' size changed to {e.UpdatedHeight}");
+                break;
+            default:
+                Console.WriteLine($"Rokt {placementName} event: {roktEvent.GetType().Name}");
+                break;
+        }
     }
 }

--- a/Sdk/MParticle.Maui.Sdk/MParticle.Maui.Sdk.csproj
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.Maui.Sdk.csproj
@@ -66,7 +66,7 @@
     
     <ItemGroup Condition="$(TargetFramework.Contains('android'))">
         <!--mParticle Android Core SDK-->
-        <AndroidLibrary Include=".\android\native\MParticleBinding\MParticleBinding\bin\Release\$(TargetFramework)\outputs\deps\com.mparticle-android-core-5.74.3.aar">
+        <AndroidLibrary Include=".\android\native\MParticleBinding\MParticleBinding\bin\Release\$(TargetFramework)\outputs\deps\com.mparticle-android-core-5.78.5.aar">
             <Bind>true</Bind>
             <Link>false</Link>
             <Pack>true</Pack>

--- a/Sdk/MParticle.Maui.Sdk/MParticle.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.cs
@@ -303,8 +303,7 @@ public class RoktApiWrapper : RoktApi
     public override void SelectPlacements(string identifier, 
         Dictionary<string, string> attributes = null,
         Dictionary<string, RoktEmbeddedView> embeddedViews = null,
-        RoktConfig config = null,
-        RoktEventCallback callbacks = null)
+        RoktConfig config = null)
     {
         
         // Store embedded views for height updates
@@ -321,7 +320,7 @@ public class RoktApiWrapper : RoktApi
         var nsConfig = Utils.ConvertToMpRoktConfig(config);
         
         // Create enhanced callbacks that include height management
-        var enhancedCallbacks = Utils.ConvertToMpRoktEventCallback(callbacks, (identifier, height) =>
+        var enhancedCallbacks = Utils.ConvertToMpRoktEventCallback((RoktEventCallback)null, (identifier, height) =>
         {
             // Update the MAUI view's HeightRequest when native view size changes
             if (EmbeddedViews.TryGetValue(identifier, out var view))
@@ -336,15 +335,13 @@ public class RoktApiWrapper : RoktApi
     public override void SelectShoppableAds(
         string identifier,
         Dictionary<string, string> attributes = null,
-        RoktConfig config = null,
-        RoktEventCallback callbacks = null)
+        RoktConfig config = null)
     {
         var nsAttributes = Utils.ConvertToNSDictionary<NSString, NSString>(attributes)
             ?? new NSDictionary<NSString, NSString>();
         var nsConfig = Utils.ConvertToMpRoktConfig(config);
-        var enhancedCallbacks = Utils.ConvertToMpRoktEventCallback(callbacks);
 
-        _roktInstance.SelectShoppableAds(identifier, nsAttributes, nsConfig, enhancedCallbacks);
+        _roktInstance.SelectShoppableAds(identifier, nsAttributes, nsConfig, null);
     }
 
     public override void Events(string identifier, Action<RoktEvent> onEvent)
@@ -609,8 +606,7 @@ public class RoktApiWrapper : RoktApi
         string identifier,
         Dictionary<string, string> attributes = null,
         Dictionary<string, RoktEmbeddedView> embeddedViews = null,
-        RoktConfig config = null,
-        RoktEventCallback callbacks = null)
+        RoktConfig config = null)
     {
         if (_mparticleInstance == null)
         {
@@ -620,13 +616,11 @@ public class RoktApiWrapper : RoktApi
         var javaAttributes = Utils.ConvertToDictionary(attributes);
         var javaEmbeddedViews = Utils.ConvertEmbeddedViewsToWeakReferenceDictionary(embeddedViews);
         var javaConfig = Utils.ConvertToRoktConfig(config);
-        var javaCallbacks = Utils.ConvertToRoktEventCallback(callbacks);
-
         var roktInstance = _mparticleInstance.Rokt();
         if (roktInstance != null)
         {
             // Android Rokt API: selectPlacements(identifier, attributes, callbacks, embeddedViews, fontTypefaces, config)
-            roktInstance.SelectPlacements(identifier, javaAttributes, javaCallbacks, javaEmbeddedViews, null, javaConfig);
+            roktInstance.SelectPlacements(identifier, javaAttributes, null, javaEmbeddedViews, null, javaConfig);
         }
         else
         {
@@ -637,8 +631,7 @@ public class RoktApiWrapper : RoktApi
     public override void SelectShoppableAds(
         string identifier,
         Dictionary<string, string> attributes = null,
-        RoktConfig config = null,
-        RoktEventCallback callbacks = null)
+        RoktConfig config = null)
     {
         // Parity with Flutter/React Native: Android exposes the API but does not
         // have native Shoppable Ads support yet. Keep a no-op bridge with a warning log.
@@ -709,8 +702,7 @@ public class NoOpRoktApiWrapper : RoktApi
         string identifier,
         Dictionary<string, string> attributes = null,
         Dictionary<string, RoktEmbeddedView> embeddedViews = null,
-        RoktConfig config = null,
-        RoktEventCallback callbacks = null)
+        RoktConfig config = null)
     {
         Console.WriteLine(MParticleSDK.SdkNotInitializedWarning);
     }
@@ -718,8 +710,7 @@ public class NoOpRoktApiWrapper : RoktApi
     public override void SelectShoppableAds(
         string identifier,
         Dictionary<string, string> attributes = null,
-        RoktConfig config = null,
-        RoktEventCallback callbacks = null)
+        RoktConfig config = null)
     {
         Console.WriteLine(MParticleSDK.SdkNotInitializedWarning);
     }

--- a/Sdk/MParticle.Maui.Sdk/MParticle.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.cs
@@ -319,15 +319,15 @@ public class RoktApiWrapper : RoktApi
         var nsEmbeddedViews = Utils.ConvertEmbeddedViewsToNSDictionary(embeddedViews);
         var nsConfig = Utils.ConvertToMpRoktConfig(config);
         
-        // Create enhanced callbacks that include height management
-        var enhancedCallbacks = Utils.ConvertToMpRoktEventCallback((RoktEventCallback)null, (identifier, height) =>
+        // Keep embedded view heights in sync with native iOS size events.
+        Action<iOSBinding.RoktEvent> enhancedCallbacks = roktEvent =>
         {
-            // Update the MAUI view's HeightRequest when native view size changes
-            if (EmbeddedViews.TryGetValue(identifier, out var view))
+            if (roktEvent is iOSBinding.RoktEmbeddedSizeChanged sizeChanged &&
+                EmbeddedViews.TryGetValue(sizeChanged.Identifier, out var view))
             {
-                view.HeightRequest = height;
+                view.HeightRequest = sizeChanged.UpdatedHeight;
             }
-        });
+        };
 
         _roktInstance.SelectPlacements(identifier, nsAttributes, nsEmbeddedViews, nsConfig, enhancedCallbacks);
     }

--- a/Sdk/MParticle.Maui.Sdk/MParticle.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.cs
@@ -345,6 +345,16 @@ public class RoktApiWrapper : RoktApi
 
         _roktInstance.SelectShoppableAds(identifier, nsAttributes, nsConfig, enhancedCallbacks);
     }
+
+    public override void Events(string identifier, Action<RoktEvent> onEvent)
+    {
+        _roktInstance.Events(identifier, Utils.ConvertToMpRoktEventCallback(onEvent));
+    }
+
+    public override void GlobalEvents(Action<RoktEvent> onEvent)
+    {
+        _roktInstance.GlobalEvents(Utils.ConvertToMpRoktEventCallback(onEvent));
+    }
 }
 
 public class RoktEmbeddedViewHandler : ViewHandler<RoktEmbeddedView, iOSBinding.RoktEmbeddedView>
@@ -632,6 +642,16 @@ public class RoktApiWrapper : RoktApi
         // have native Shoppable Ads support yet. Keep a no-op bridge with a warning log.
         Console.WriteLine("[mParticle MAUI SDK] SelectShoppableAds is not yet supported on Android.");
     }
+
+    public override void Events(string identifier, Action<RoktEvent> onEvent)
+    {
+        Console.WriteLine("[mParticle MAUI SDK] Rokt events subscription is not yet supported on Android.");
+    }
+
+    public override void GlobalEvents(Action<RoktEvent> onEvent)
+    {
+        Console.WriteLine("[mParticle MAUI SDK] Rokt global events subscription is not yet supported on Android.");
+    }
 }
 
 public class RoktEmbeddedViewHandler : ViewHandler<RoktEmbeddedView, global::Android.Views.View>
@@ -669,6 +689,16 @@ public class NoOpRoktApiWrapper : RoktApi
         Dictionary<string, string> attributes = null,
         RoktConfig config = null,
         RoktEventCallback callbacks = null)
+    {
+        Console.WriteLine(MParticleSDK.SdkNotInitializedWarning);
+    }
+
+    public override void Events(string identifier, Action<RoktEvent> onEvent)
+    {
+        Console.WriteLine(MParticleSDK.SdkNotInitializedWarning);
+    }
+
+    public override void GlobalEvents(Action<RoktEvent> onEvent)
     {
         Console.WriteLine(MParticleSDK.SdkNotInitializedWarning);
     }

--- a/Sdk/MParticle.Maui.Sdk/MParticle.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.cs
@@ -595,7 +595,7 @@ public class MParticleSDKImpl : MParticleSDK
 public class RoktApiWrapper : RoktApi
 {
     private readonly mParticle.MAUI.AndroidBinding.MParticle _mparticleInstance;
-    private readonly List<object> _eventSubscriptions = new List<object>();
+    private static readonly List<object> EventSubscriptions = new List<object>();
 
     internal RoktApiWrapper(mParticle.MAUI.AndroidBinding.MParticle mparticleInstance)
     {
@@ -665,10 +665,10 @@ public class RoktApiWrapper : RoktApi
         var listener = Utils.ConvertToRoktFlowEventListener(onEvent);
         var subscription = MParticleSdkBinding.SubscribeToEvents(roktInstance, identifier, listener);
 
-        lock (_eventSubscriptions)
+        lock (EventSubscriptions)
         {
-            _eventSubscriptions.Add(listener);
-            _eventSubscriptions.Add(subscription);
+            EventSubscriptions.Add(listener);
+            EventSubscriptions.Add(subscription);
         }
     }
 

--- a/Sdk/MParticle.Maui.Sdk/MParticle.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticle.cs
@@ -9,6 +9,7 @@ using mParticle.MAUI.Android.Wrappers;
 using mParticle.MAUI.Android;
 using Android.Util;
 using Android.Views;
+using Com.Mparticle.Mparticlebinding;
 using Object = Java.Lang.Object;
 using Java.Util;
 using Kotlin.Jvm.Functions;
@@ -597,6 +598,7 @@ public class MParticleSDKImpl : MParticleSDK
 public class RoktApiWrapper : RoktApi
 {
     private readonly mParticle.MAUI.AndroidBinding.MParticle _mparticleInstance;
+    private readonly List<object> _eventSubscriptions = new List<object>();
 
     internal RoktApiWrapper(mParticle.MAUI.AndroidBinding.MParticle mparticleInstance)
     {
@@ -645,7 +647,36 @@ public class RoktApiWrapper : RoktApi
 
     public override void Events(string identifier, Action<RoktEvent> onEvent)
     {
-        Console.WriteLine("[mParticle MAUI SDK] Rokt events subscription is not yet supported on Android.");
+        if (_mparticleInstance == null)
+        {
+            Console.WriteLine(MParticleSDK.SdkNotInitializedWarning);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(identifier))
+        {
+            throw new ArgumentException("identifier cannot be null or empty.", nameof(identifier));
+        }
+
+        if (onEvent == null)
+        {
+            throw new ArgumentNullException(nameof(onEvent));
+        }
+
+        var roktInstance = _mparticleInstance.Rokt();
+        if (roktInstance == null)
+        {
+            throw new InvalidOperationException("Rokt instance is not available. Make sure mParticle is properly initialized.");
+        }
+
+        var listener = Utils.ConvertToRoktFlowEventListener(onEvent);
+        var subscription = MParticleSdkBinding.SubscribeToEvents(roktInstance, identifier, listener);
+
+        lock (_eventSubscriptions)
+        {
+            _eventSubscriptions.Add(listener);
+            _eventSubscriptions.Add(subscription);
+        }
     }
 
     public override void GlobalEvents(Action<RoktEvent> onEvent)

--- a/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
@@ -414,13 +414,22 @@ public sealed class Error
     public String Code;
 }
 
+public enum RoktColorMode
+{
+    Light = 0,
+    Dark = 1,
+    System = 2
+}
+
 public sealed class RoktConfig
 {
+    public RoktColorMode ColorMode { get; set; }
     public int? CacheDuration { get; set; }
     public Dictionary<string, string> CacheAttributes { get; set; }
     
     public RoktConfig()
     {
+        ColorMode = RoktColorMode.System;
         CacheAttributes = new Dictionary<string, string>();
     }
 }

--- a/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
@@ -659,20 +659,6 @@ public sealed class RoktCartItemDevicePay : RoktEvent
     }
 }
 
-public sealed class RoktEventCallback
-{
-    public Action OnLoad { get; set; }
-    public Action<string> OnUnLoad { get; set; }
-    public Action OnShouldShowLoadingIndicator { get; set; }
-    public Action OnShouldHideLoadingIndicator { get; set; }
-    public Action<string, float> OnEmbeddedSizeChange { get; set; }
-    public Action<RoktEvent> OnEvent { get; set; }
-    
-    public RoktEventCallback()
-    {
-    }
-}
-
 public abstract class RoktApi
 {
     /// <summary>

--- a/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
@@ -707,6 +707,19 @@ public abstract class RoktApi
         Dictionary<string, string> attributes = null,
         RoktConfig config = null,
         RoktEventCallback callbacks = null);
+
+    /// <summary>
+    /// Subscribes to events for a specific placement identifier.
+    /// </summary>
+    /// <param name="identifier">Placement identifier.</param>
+    /// <param name="onEvent">Event callback.</param>
+    public abstract void Events(string identifier, Action<RoktEvent> onEvent);
+
+    /// <summary>
+    /// Subscribes to global Rokt events.
+    /// </summary>
+    /// <param name="onEvent">Event callback.</param>
+    public abstract void GlobalEvents(Action<RoktEvent> onEvent);
 }
 
 public abstract class MParticleSDK

--- a/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
@@ -682,13 +682,11 @@ public abstract class RoktApi
     /// <param name="attributes">Optional attributes dictionary</param>
     /// <param name="embeddedViews">Optional embedded views dictionary</param>
     /// <param name="config">Optional Rokt configuration</param>
-    /// <param name="callbacks">Optional event callbacks</param>
     public abstract void SelectPlacements(
         string identifier, 
         Dictionary<string, string> attributes = null,
         Dictionary<string, RoktEmbeddedView> embeddedViews = null,
-        RoktConfig config = null,
-        RoktEventCallback callbacks = null);
+        RoktConfig config = null);
 
     /// <summary>
     /// Displays a Shoppable Ads overlay placement.
@@ -701,12 +699,10 @@ public abstract class RoktApi
     /// <param name="identifier">The view name / placement identifier.</param>
     /// <param name="attributes">Optional attributes for targeting.</param>
     /// <param name="config">Optional display configuration (color mode, caching).</param>
-    /// <param name="callbacks">Optional event callbacks.</param>
     public abstract void SelectShoppableAds(
         string identifier,
         Dictionary<string, string> attributes = null,
-        RoktConfig config = null,
-        RoktEventCallback callbacks = null);
+        RoktConfig config = null);
 
     /// <summary>
     /// Subscribes to events for a specific placement identifier.

--- a/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
+++ b/Sdk/MParticle.Maui.Sdk/MParticleAbstractions.cs
@@ -434,6 +434,231 @@ public sealed class RoktConfig
     }
 }
 
+public abstract class RoktEvent
+{
+}
+
+public sealed class RoktInitComplete : RoktEvent
+{
+    public bool Success { get; }
+
+    public RoktInitComplete(bool success)
+    {
+        Success = success;
+    }
+}
+
+public sealed class RoktShowLoadingIndicator : RoktEvent
+{
+}
+
+public sealed class RoktHideLoadingIndicator : RoktEvent
+{
+}
+
+public sealed class RoktPlacementReady : RoktEvent
+{
+    public string Identifier { get; }
+
+    public RoktPlacementReady(string identifier)
+    {
+        Identifier = identifier;
+    }
+}
+
+public sealed class RoktPlacementInteractive : RoktEvent
+{
+    public string Identifier { get; }
+
+    public RoktPlacementInteractive(string identifier)
+    {
+        Identifier = identifier;
+    }
+}
+
+public sealed class RoktPlacementClosed : RoktEvent
+{
+    public string Identifier { get; }
+
+    public RoktPlacementClosed(string identifier)
+    {
+        Identifier = identifier;
+    }
+}
+
+public sealed class RoktPlacementCompleted : RoktEvent
+{
+    public string Identifier { get; }
+
+    public RoktPlacementCompleted(string identifier)
+    {
+        Identifier = identifier;
+    }
+}
+
+public sealed class RoktPlacementFailure : RoktEvent
+{
+    public string Identifier { get; }
+
+    public RoktPlacementFailure(string identifier)
+    {
+        Identifier = identifier;
+    }
+}
+
+public sealed class RoktOfferEngagement : RoktEvent
+{
+    public string Identifier { get; }
+
+    public RoktOfferEngagement(string identifier)
+    {
+        Identifier = identifier;
+    }
+}
+
+public sealed class RoktPositiveEngagement : RoktEvent
+{
+    public string Identifier { get; }
+
+    public RoktPositiveEngagement(string identifier)
+    {
+        Identifier = identifier;
+    }
+}
+
+public sealed class RoktFirstPositiveEngagement : RoktEvent
+{
+    public string Identifier { get; }
+    public Action<Dictionary<string, string>> SetFulfillmentAttributes { get; }
+
+    public RoktFirstPositiveEngagement(string identifier, Action<Dictionary<string, string>> setFulfillmentAttributes)
+    {
+        Identifier = identifier;
+        SetFulfillmentAttributes = setFulfillmentAttributes;
+    }
+}
+
+public sealed class RoktOpenUrl : RoktEvent
+{
+    public string Identifier { get; }
+    public string Url { get; }
+
+    public RoktOpenUrl(string identifier, string url)
+    {
+        Identifier = identifier;
+        Url = url;
+    }
+}
+
+public sealed class RoktEmbeddedSizeChanged : RoktEvent
+{
+    public string Identifier { get; }
+    public double UpdatedHeight { get; }
+
+    public RoktEmbeddedSizeChanged(string identifier, double updatedHeight)
+    {
+        Identifier = identifier;
+        UpdatedHeight = updatedHeight;
+    }
+}
+
+public sealed class RoktCartItemInstantPurchaseInitiated : RoktEvent
+{
+    public string Identifier { get; }
+    public string CatalogItemId { get; }
+    public string CartItemId { get; }
+
+    public RoktCartItemInstantPurchaseInitiated(string identifier, string catalogItemId, string cartItemId)
+    {
+        Identifier = identifier;
+        CatalogItemId = catalogItemId;
+        CartItemId = cartItemId;
+    }
+}
+
+public sealed class RoktCartItemInstantPurchase : RoktEvent
+{
+    public string Identifier { get; }
+    public string Name { get; }
+    public string CartItemId { get; }
+    public string CatalogItemId { get; }
+    public string Currency { get; }
+    public string Description { get; }
+    public string LinkedProductId { get; }
+    public string ProviderData { get; }
+    public decimal? Quantity { get; }
+    public decimal? TotalPrice { get; }
+    public decimal? UnitPrice { get; }
+
+    public RoktCartItemInstantPurchase(
+        string identifier,
+        string name,
+        string cartItemId,
+        string catalogItemId,
+        string currency,
+        string description,
+        string linkedProductId,
+        string providerData,
+        decimal? quantity,
+        decimal? totalPrice,
+        decimal? unitPrice)
+    {
+        Identifier = identifier;
+        Name = name;
+        CartItemId = cartItemId;
+        CatalogItemId = catalogItemId;
+        Currency = currency;
+        Description = description;
+        LinkedProductId = linkedProductId;
+        ProviderData = providerData;
+        Quantity = quantity;
+        TotalPrice = totalPrice;
+        UnitPrice = unitPrice;
+    }
+}
+
+public sealed class RoktCartItemInstantPurchaseFailure : RoktEvent
+{
+    public string Identifier { get; }
+    public string CatalogItemId { get; }
+    public string CartItemId { get; }
+    public string Error { get; }
+
+    public RoktCartItemInstantPurchaseFailure(string identifier, string catalogItemId, string cartItemId, string error)
+    {
+        Identifier = identifier;
+        CatalogItemId = catalogItemId;
+        CartItemId = cartItemId;
+        Error = error;
+    }
+}
+
+public sealed class RoktInstantPurchaseDismissal : RoktEvent
+{
+    public string Identifier { get; }
+
+    public RoktInstantPurchaseDismissal(string identifier)
+    {
+        Identifier = identifier;
+    }
+}
+
+public sealed class RoktCartItemDevicePay : RoktEvent
+{
+    public string Identifier { get; }
+    public string CatalogItemId { get; }
+    public string CartItemId { get; }
+    public string PaymentProvider { get; }
+
+    public RoktCartItemDevicePay(string identifier, string catalogItemId, string cartItemId, string paymentProvider)
+    {
+        Identifier = identifier;
+        CatalogItemId = catalogItemId;
+        CartItemId = cartItemId;
+        PaymentProvider = paymentProvider;
+    }
+}
+
 public sealed class RoktEventCallback
 {
     public Action OnLoad { get; set; }
@@ -441,6 +666,7 @@ public sealed class RoktEventCallback
     public Action OnShouldShowLoadingIndicator { get; set; }
     public Action OnShouldHideLoadingIndicator { get; set; }
     public Action<string, float> OnEmbeddedSizeChange { get; set; }
+    public Action<RoktEvent> OnEvent { get; set; }
     
     public RoktEventCallback()
     {

--- a/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
@@ -312,6 +312,11 @@ internal static class Utils
         return new RoktEventCallbackWrapper(callbacks, heightCallback);
     }
 
+    internal static Com.Mparticle.Mparticlebinding.IRoktFlowEventListener ConvertToRoktFlowEventListener(Action<RoktEvent> onEvent)
+    {
+        return new RoktFlowEventListenerWrapper(onEvent);
+    }
+
     public class RoktEventCallbackWrapper : Java.Lang.Object, AndroidBinding.IMpRoktEventCallback
     {
         private readonly RoktEventCallback _callbacks;
@@ -355,6 +360,25 @@ internal static class Utils
             
             // Call internal height management callback
             _heightCallback?.Invoke(identifier, height);
+        }
+    }
+
+    public class RoktFlowEventListenerWrapper : Java.Lang.Object, Com.Mparticle.Mparticlebinding.IRoktFlowEventListener
+    {
+        private readonly Action<RoktEvent> _onEvent;
+
+        public RoktFlowEventListenerWrapper(Action<RoktEvent> onEvent)
+        {
+            _onEvent = onEvent;
+        }
+
+        public void OnEvent(AndroidBinding.IRoktEvent e)
+        {
+            var crossPlatformEvent = ConvertToCrossPlatformRoktEvent(e);
+            if (crossPlatformEvent != null)
+            {
+                _onEvent?.Invoke(crossPlatformEvent);
+            }
         }
     }
 

--- a/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
@@ -300,67 +300,9 @@ internal static class Utils
         return builder.Build();
     }
 
-    internal static AndroidBinding.IMpRoktEventCallback ConvertToRoktEventCallback(RoktEventCallback callbacks)
-    {
-        return ConvertToRoktEventCallback(callbacks, null);
-    }
-
-    internal static AndroidBinding.IMpRoktEventCallback ConvertToRoktEventCallback(
-        RoktEventCallback callbacks, 
-        Action<string, double> heightCallback)
-    {
-        return new RoktEventCallbackWrapper(callbacks, heightCallback);
-    }
-
     internal static Com.Mparticle.Mparticlebinding.IRoktFlowEventListener ConvertToRoktFlowEventListener(Action<RoktEvent> onEvent)
     {
         return new RoktFlowEventListenerWrapper(onEvent);
-    }
-
-    public class RoktEventCallbackWrapper : Java.Lang.Object, AndroidBinding.IMpRoktEventCallback
-    {
-        private readonly RoktEventCallback _callbacks;
-        private readonly Action<string, double> _heightCallback;
-
-        public RoktEventCallbackWrapper(RoktEventCallback callbacks, Action<string, double> heightCallback = null)
-        {
-            _callbacks = callbacks;
-            _heightCallback = heightCallback;
-        }
-
-        public void OnLoad()
-        {
-            _callbacks?.OnLoad?.Invoke();
-            _callbacks?.OnEvent?.Invoke(new RoktPlacementReady(null));
-        }
-
-        public void OnUnload(AndroidBinding.UnloadReasons reason)
-        {
-            _callbacks?.OnUnLoad?.Invoke(reason?.ToString() ?? "Unknown");
-            _callbacks?.OnEvent?.Invoke(new RoktPlacementClosed(null));
-        }
-
-        public void OnShouldShowLoadingIndicator()
-        {
-            _callbacks?.OnShouldShowLoadingIndicator?.Invoke();
-            _callbacks?.OnEvent?.Invoke(new RoktShowLoadingIndicator());
-        }
-
-        public void OnShouldHideLoadingIndicator()
-        {
-            _callbacks?.OnShouldHideLoadingIndicator?.Invoke();
-            _callbacks?.OnEvent?.Invoke(new RoktHideLoadingIndicator());
-        }
-
-        public void OnEmbeddedSizeChange(string identifier, int height)
-        {
-            // Call user's callback if provided
-            _callbacks?.OnEmbeddedSizeChange?.Invoke(identifier, (float)height);
-            _callbacks?.OnEvent?.Invoke(new RoktEmbeddedSizeChanged(identifier, height));
-            
-            // Call internal height management callback
-            _heightCallback?.Invoke(identifier, height);
-        }
     }
 
     public class RoktFlowEventListenerWrapper : Java.Lang.Object, Com.Mparticle.Mparticlebinding.IRoktFlowEventListener

--- a/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
@@ -326,30 +326,81 @@ internal static class Utils
         public void OnLoad()
         {
             _callbacks?.OnLoad?.Invoke();
+            _callbacks?.OnEvent?.Invoke(new RoktPlacementReady(null));
         }
 
         public void OnUnload(AndroidBinding.UnloadReasons reason)
         {
             _callbacks?.OnUnLoad?.Invoke(reason?.ToString() ?? "Unknown");
+            _callbacks?.OnEvent?.Invoke(new RoktPlacementClosed(null));
         }
 
         public void OnShouldShowLoadingIndicator()
         {
             _callbacks?.OnShouldShowLoadingIndicator?.Invoke();
+            _callbacks?.OnEvent?.Invoke(new RoktShowLoadingIndicator());
         }
 
         public void OnShouldHideLoadingIndicator()
         {
             _callbacks?.OnShouldHideLoadingIndicator?.Invoke();
+            _callbacks?.OnEvent?.Invoke(new RoktHideLoadingIndicator());
         }
 
         public void OnEmbeddedSizeChange(string identifier, int height)
         {
             // Call user's callback if provided
             _callbacks?.OnEmbeddedSizeChange?.Invoke(identifier, (float)height);
+            _callbacks?.OnEvent?.Invoke(new RoktEmbeddedSizeChanged(identifier, height));
             
             // Call internal height management callback
             _heightCallback?.Invoke(identifier, height);
+        }
+    }
+
+    internal static RoktEvent ConvertToCrossPlatformRoktEvent(AndroidBinding.IRoktEvent roktEvent)
+    {
+        switch (roktEvent)
+        {
+            case AndroidBinding.IRoktEvent.InitComplete e:
+                return new RoktInitComplete(e.Success);
+            case AndroidBinding.IRoktEvent.ShowLoadingIndicator:
+                return new RoktShowLoadingIndicator();
+            case AndroidBinding.IRoktEvent.HideLoadingIndicator:
+                return new RoktHideLoadingIndicator();
+            case AndroidBinding.IRoktEvent.PlacementReady e:
+                return new RoktPlacementReady(e.PlacementId);
+            case AndroidBinding.IRoktEvent.PlacementInteractive e:
+                return new RoktPlacementInteractive(e.PlacementId);
+            case AndroidBinding.IRoktEvent.PlacementClosed e:
+                return new RoktPlacementClosed(e.PlacementId);
+            case AndroidBinding.IRoktEvent.PlacementCompleted e:
+                return new RoktPlacementCompleted(e.PlacementId);
+            case AndroidBinding.IRoktEvent.PlacementFailure e:
+                return new RoktPlacementFailure(e.PlacementId);
+            case AndroidBinding.IRoktEvent.OfferEngagement e:
+                return new RoktOfferEngagement(e.PlacementId);
+            case AndroidBinding.IRoktEvent.PositiveEngagement e:
+                return new RoktPositiveEngagement(e.PlacementId);
+            case AndroidBinding.IRoktEvent.FirstPositiveEngagement e:
+                return new RoktFirstPositiveEngagement(e.PlacementId, null);
+            case AndroidBinding.IRoktEvent.OpenUrl e:
+                return new RoktOpenUrl(e.PlacementId, e.Url);
+            case AndroidBinding.IRoktEvent.CartItemInstantPurchase e:
+                return new RoktCartItemInstantPurchase(
+                    e.PlacementId,
+                    null,
+                    e.CartItemId,
+                    e.CatalogItemId,
+                    e.Currency,
+                    e.Description,
+                    e.LinkedProductId,
+                    string.Empty,
+                        (decimal)e.Quantity,
+                        (decimal)e.TotalPrice,
+                        (decimal)e.UnitPrice);
+            default:
+                return null;
         }
     }
 

--- a/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
@@ -378,7 +378,7 @@ internal static class Utils
                     e.Currency,
                     e.Description,
                     e.LinkedProductId,
-                    string.Empty,
+                    null,
                         (decimal)e.Quantity,
                         (decimal)e.TotalPrice,
                         (decimal)e.UnitPrice);

--- a/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
@@ -364,7 +364,9 @@ internal static class Utils
             case AndroidBinding.IRoktEvent.PositiveEngagement e:
                 return new RoktPositiveEngagement(e.PlacementId);
             case AndroidBinding.IRoktEvent.FirstPositiveEngagement e:
-                return new RoktFirstPositiveEngagement(e.PlacementId, null);
+                return new RoktFirstPositiveEngagement(
+                    e.PlacementId,
+                    _ => Console.WriteLine("[mParticle MAUI SDK] SetFulfillmentAttributes is not supported on Android."));
             case AndroidBinding.IRoktEvent.OpenUrl e:
                 return new RoktOpenUrl(e.PlacementId, e.Url);
             case AndroidBinding.IRoktEvent.CartItemInstantPurchase e:

--- a/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/android/Utils/Utils.cs
@@ -289,6 +289,7 @@ internal static class Utils
             return null;
 
         var builder = new Com.Mparticle.Rokt.RoktConfig.Builder();
+        builder.ColorMode(ConvertToRoktColorMode(config.ColorMode));
 
         if (config.CacheDuration.HasValue || (config.CacheAttributes != null && config.CacheAttributes.Count > 0))
         {
@@ -298,6 +299,20 @@ internal static class Utils
         }
 
         return builder.Build();
+    }
+
+    internal static Com.Mparticle.Rokt.RoktConfig.ColorMode ConvertToRoktColorMode(RoktColorMode colorMode)
+    {
+        switch (colorMode)
+        {
+            case RoktColorMode.Light:
+                return Com.Mparticle.Rokt.RoktConfig.ColorMode.Light!;
+            case RoktColorMode.Dark:
+                return Com.Mparticle.Rokt.RoktConfig.ColorMode.Dark!;
+            case RoktColorMode.System:
+            default:
+                return Com.Mparticle.Rokt.RoktConfig.ColorMode.System!;
+        }
     }
 
     internal static Com.Mparticle.Mparticlebinding.IRoktFlowEventListener ConvertToRoktFlowEventListener(Action<RoktEvent> onEvent)

--- a/Sdk/MParticle.Maui.Sdk/android/native/MParticleBinding/MParticleBinding/build.gradle.kts
+++ b/Sdk/MParticle.Maui.Sdk/android/native/MParticleBinding/MParticleBinding/build.gradle.kts
@@ -50,7 +50,7 @@ project.afterEvaluate {
             if (this.name.contains(".aar")) {
                 // Rename mparticle AAR to the expected name
                 if (this.name.contains("android-core")) {
-                    this.name = "com.mparticle-android-core-5.74.3.aar"
+                    this.name = "com.mparticle-android-core-5.78.5.aar"
                 } else {
                     val groupName = this.file.parentFile.parentFile.parentFile.parentFile.name
                     this.name = groupName + "-" + this.name

--- a/Sdk/MParticle.Maui.Sdk/android/native/MParticleBinding/MParticleBinding/src/main/java/com/mparticle/mparticlebinding/MParticleSdkBinding.kt
+++ b/Sdk/MParticle.Maui.Sdk/android/native/MParticleBinding/MParticleBinding/src/main/java/com/mparticle/mparticlebinding/MParticleSdkBinding.kt
@@ -1,6 +1,29 @@
 package com.mparticle.mparticlebinding
 
+import com.mparticle.Rokt
+import com.mparticle.RoktEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+fun interface RoktFlowEventListener {
+    fun onEvent(event: RoktEvent)
+}
+
 class MParticleSdkBinding {
     companion object {
+        @JvmStatic
+        fun subscribeToEvents(
+            rokt: Rokt,
+            identifier: String,
+            listener: RoktFlowEventListener,
+        ): Job =
+            CoroutineScope(Dispatchers.Main.immediate).launch {
+                rokt.events(identifier).collect { event ->
+                    listener.onEvent(event)
+                }
+            }
     }
 }

--- a/Sdk/MParticle.Maui.Sdk/android/native/MParticleBinding/gradle/libs.versions.toml
+++ b/Sdk/MParticle.Maui.Sdk/android/native/MParticleBinding/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 appcompat = "1.7.0"
 material = "1.12.0"
-mparticle = "5.74.3"
+mparticle = "5.78.5"
 coroutines = "1.7.3"
 lifecycle = "2.8.6"
 

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
@@ -1086,27 +1086,52 @@ namespace mParticle.MAUI.iOSBinding {
         MPRokt Rokt { get; }
     }
 
-    // typedef NS_ENUM(NSInteger, RoktColorMode)
-    [Native]
-    public enum RoktColorMode : long
+    // @interface RoktCacheConfig : NSObject
+    [BaseType(typeof(NSObject))]
+    interface RoktCacheConfig
     {
-        Light = 0,
-        Dark = 1,
-        System = 2
+        // + (double)maxCacheDuration;
+        [Static]
+        [Export("maxCacheDuration")]
+        double MaxCacheDuration { get; }
+
+        // - (nonnull instancetype)initWithCacheDuration:(double)cacheDuration cacheAttributes:(NSDictionary<NSString *,NSString *> * _Nullable)cacheAttributes;
+        [Export("initWithCacheDuration:cacheAttributes:")]
+        NativeHandle Constructor(double cacheDuration, [NullAllowed] NSDictionary<NSString, NSString> cacheAttributes);
+    }
+
+    // @interface RoktConfigBuilder : NSObject
+    [BaseType(typeof(NSObject))]
+    interface RoktConfigBuilder
+    {
+        // - (nonnull RoktConfigBuilder *)colorMode:(RoktColorMode)colorMode;
+        [Export("colorMode:")]
+        RoktConfigBuilder ColorMode(RoktColorMode colorMode);
+
+        // - (nonnull RoktConfigBuilder *)cacheConfig:(RoktCacheConfig * _Nonnull)cacheConfig;
+        [Export("cacheConfig:")]
+        RoktConfigBuilder CacheConfig(RoktCacheConfig cacheConfig);
+
+        // - (nonnull RoktConfig *)build;
+        [Export("build")]
+        RoktConfig Build();
     }
 
     // @interface RoktConfig : NSObject
     [BaseType(typeof(NSObject))]
-    [Protocol]
     interface RoktConfig
     {
-        // @property (nonatomic, copy, nullable) NSNumber *cacheDuration;
-        [NullAllowed, Export("cacheDuration", ArgumentSemantic.Copy)]
-        NSNumber CacheDuration { get; set; }
+        // - (nonnull instancetype)initWithColorMode:(RoktColorMode)colorMode cacheConfig:(RoktCacheConfig * _Nonnull)cacheConfig;
+        [Export("initWithColorMode:cacheConfig:")]
+        NativeHandle Constructor(RoktColorMode colorMode, RoktCacheConfig cacheConfig);
 
-        // @property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *cacheAttributes;
-        [NullAllowed, Export("cacheAttributes", ArgumentSemantic.Copy)]
-        NSDictionary<NSString, NSString> CacheAttributes { get; set; }
+        // @property (nonatomic, readonly) RoktColorMode colorMode;
+        [Export("colorMode", ArgumentSemantic.Assign)]
+        RoktColorMode ColorMode { get; }
+
+        // @property (nonatomic, strong, readonly, nonnull) RoktCacheConfig *cacheConfig;
+        [Export("cacheConfig", ArgumentSemantic.Strong)]
+        RoktCacheConfig CacheConfig { get; }
     }
 
     // @interface RoktEmbeddedView : UIView

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
@@ -1329,6 +1329,10 @@ namespace mParticle.MAUI.iOSBinding {
         [Export("currency", ArgumentSemantic.Strong)]
         string Currency { get; }
 
+        // @property (nonatomic, strong, nonnull) NSString *description;
+        [Export("description", ArgumentSemantic.Strong)]
+        string ItemDescription { get; }
+
         // @property (nonatomic, strong, nullable) NSString *linkedProductId;
         [NullAllowed, Export("linkedProductId", ArgumentSemantic.Strong)]
         string LinkedProductId { get; }

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/ApiDefinitions.cs
@@ -1164,10 +1164,30 @@ namespace mParticle.MAUI.iOSBinding {
     {
     }
 
+    // @interface RoktInitComplete : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktInitComplete
+    {
+        // @property (nonatomic, assign) BOOL success;
+        [Export("success")]
+        bool Success { get; }
+    }
+
     // @interface RoktPlacementReady : RoktEvent
     [BaseType(typeof(RoktEvent))]
     [Protocol]
     interface RoktPlacementReady
+    {
+        // @property (nonatomic, strong, nullable) NSString *identifier;
+        [NullAllowed, Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+    }
+
+    // @interface RoktPlacementInteractive : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktPlacementInteractive
     {
         // @property (nonatomic, strong, nullable) NSString *identifier;
         [NullAllowed, Export("identifier", ArgumentSemantic.Strong)]
@@ -1184,6 +1204,74 @@ namespace mParticle.MAUI.iOSBinding {
         string Identifier { get; }
     }
 
+    // @interface RoktPlacementCompleted : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktPlacementCompleted
+    {
+        // @property (nonatomic, strong, nullable) NSString *identifier;
+        [NullAllowed, Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+    }
+
+    // @interface RoktPlacementFailure : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktPlacementFailure
+    {
+        // @property (nonatomic, strong, nullable) NSString *identifier;
+        [NullAllowed, Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+    }
+
+    // @interface RoktOfferEngagement : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktOfferEngagement
+    {
+        // @property (nonatomic, strong, nullable) NSString *identifier;
+        [NullAllowed, Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+    }
+
+    // @interface RoktPositiveEngagement : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktPositiveEngagement
+    {
+        // @property (nonatomic, strong, nullable) NSString *identifier;
+        [NullAllowed, Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+    }
+
+    // @interface RoktFirstPositiveEngagement : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktFirstPositiveEngagement
+    {
+        // @property (nonatomic, strong, nullable) NSString *identifier;
+        [NullAllowed, Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+
+        // @property (nonatomic, copy, nullable) void (^setFulfillmentAttributes)(NSDictionary<NSString *, NSString *> *);
+        [NullAllowed, Export("setFulfillmentAttributes", ArgumentSemantic.Copy)]
+        Action<NSDictionary<NSString, NSString>> SetFulfillmentAttributes { get; set; }
+    }
+
+    // @interface RoktOpenUrl : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktOpenUrl
+    {
+        // @property (nonatomic, strong, nullable) NSString *identifier;
+        [NullAllowed, Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *url;
+        [Export("url", ArgumentSemantic.Strong)]
+        string Url { get; }
+    }
+
     // @interface RoktEmbeddedSizeChanged : RoktEvent
     [BaseType(typeof(RoktEvent))]
     [Protocol]
@@ -1196,6 +1284,124 @@ namespace mParticle.MAUI.iOSBinding {
         // @property (nonatomic, assign) CGFloat updatedHeight;
         [Export("updatedHeight")]
         nfloat UpdatedHeight { get; }
+    }
+
+    // @interface RoktCartItemInstantPurchaseInitiated : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktCartItemInstantPurchaseInitiated
+    {
+        // @property (nonatomic, strong, nonnull) NSString *identifier;
+        [Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *catalogItemId;
+        [Export("catalogItemId", ArgumentSemantic.Strong)]
+        string CatalogItemId { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *cartItemId;
+        [Export("cartItemId", ArgumentSemantic.Strong)]
+        string CartItemId { get; }
+    }
+
+    // @interface RoktCartItemInstantPurchase : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktCartItemInstantPurchase
+    {
+        // @property (nonatomic, strong, nonnull) NSString *identifier;
+        [Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+
+        // @property (nonatomic, strong, nullable) NSString *name;
+        [NullAllowed, Export("name", ArgumentSemantic.Strong)]
+        string Name { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *cartItemId;
+        [Export("cartItemId", ArgumentSemantic.Strong)]
+        string CartItemId { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *catalogItemId;
+        [Export("catalogItemId", ArgumentSemantic.Strong)]
+        string CatalogItemId { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *currency;
+        [Export("currency", ArgumentSemantic.Strong)]
+        string Currency { get; }
+
+        // @property (nonatomic, strong, nullable) NSString *linkedProductId;
+        [NullAllowed, Export("linkedProductId", ArgumentSemantic.Strong)]
+        string LinkedProductId { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *providerData;
+        [Export("providerData", ArgumentSemantic.Strong)]
+        string ProviderData { get; }
+
+        // @property (nonatomic, strong, nullable) NSDecimalNumber *quantity;
+        [NullAllowed, Export("quantity", ArgumentSemantic.Strong)]
+        NSDecimalNumber Quantity { get; }
+
+        // @property (nonatomic, strong, nullable) NSDecimalNumber *totalPrice;
+        [NullAllowed, Export("totalPrice", ArgumentSemantic.Strong)]
+        NSDecimalNumber TotalPrice { get; }
+
+        // @property (nonatomic, strong, nullable) NSDecimalNumber *unitPrice;
+        [NullAllowed, Export("unitPrice", ArgumentSemantic.Strong)]
+        NSDecimalNumber UnitPrice { get; }
+    }
+
+    // @interface RoktCartItemInstantPurchaseFailure : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktCartItemInstantPurchaseFailure
+    {
+        // @property (nonatomic, strong, nonnull) NSString *identifier;
+        [Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *catalogItemId;
+        [Export("catalogItemId", ArgumentSemantic.Strong)]
+        string CatalogItemId { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *cartItemId;
+        [Export("cartItemId", ArgumentSemantic.Strong)]
+        string CartItemId { get; }
+
+        // @property (nonatomic, strong, nullable) NSString *error;
+        [NullAllowed, Export("error", ArgumentSemantic.Strong)]
+        string Error { get; }
+    }
+
+    // @interface RoktInstantPurchaseDismissal : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktInstantPurchaseDismissal
+    {
+        // @property (nonatomic, strong, nonnull) NSString *identifier;
+        [Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+    }
+
+    // @interface RoktCartItemDevicePay : RoktEvent
+    [BaseType(typeof(RoktEvent))]
+    [Protocol]
+    interface RoktCartItemDevicePay
+    {
+        // @property (nonatomic, strong, nonnull) NSString *identifier;
+        [Export("identifier", ArgumentSemantic.Strong)]
+        string Identifier { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *catalogItemId;
+        [Export("catalogItemId", ArgumentSemantic.Strong)]
+        string CatalogItemId { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *cartItemId;
+        [Export("cartItemId", ArgumentSemantic.Strong)]
+        string CartItemId { get; }
+
+        // @property (nonatomic, strong, nonnull) NSString *paymentProvider;
+        [Export("paymentProvider", ArgumentSemantic.Strong)]
+        string PaymentProvider { get; }
     }
 
     // @interface MPRokt : NSObject

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/StructsAndEnums.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/StructsAndEnums.cs
@@ -242,4 +242,12 @@ namespace mParticle.MAUI.iOSBinding {
         MPSegmentMembershipActionDrop
     }
 
+    [Native]
+    public enum RoktColorMode : long
+    {
+        Light = 0,
+        Dark = 1,
+        System = 2
+    }
+
 }

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Foundation;
 using mParticle.MAUI.iOSBinding;
@@ -336,7 +337,18 @@ namespace mParticle.MAUI.iOS.Utils
                 return null;
             }
 
-            return value.DecimalValue;
+            var stringValue = value.StringValue;
+            if (decimal.TryParse(stringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedInvariant))
+            {
+                return parsedInvariant;
+            }
+
+            if (decimal.TryParse(stringValue, NumberStyles.Any, CultureInfo.CurrentCulture, out var parsedCurrent))
+            {
+                return parsedCurrent;
+            }
+
+            return null;
         }
 
         internal static NSDictionary<NSString, NSString> ConvertToNSDictionary<T, V>(Dictionary<string, string> dictionary) where T : NSString where V : NSString

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
@@ -224,14 +224,34 @@ namespace mParticle.MAUI.iOS.Utils
             if (config == null)
                 return null;
 
-            var mpConfig = new iOSBinding.RoktConfig();
-            
-            if (config.CacheDuration.HasValue)
-                mpConfig.CacheDuration = NSNumber.FromInt32(config.CacheDuration.Value);
-                
-            mpConfig.CacheAttributes = ConvertToNSDictionary<NSString, NSString>(config.CacheAttributes);
-            
-            return mpConfig;
+            var builder = new iOSBinding.RoktConfigBuilder()
+                .ColorMode(ConvertToMpRoktColorMode(config.ColorMode));
+
+            if (config.CacheDuration.HasValue || (config.CacheAttributes != null && config.CacheAttributes.Any()))
+            {
+                var cacheDuration = config.CacheDuration.HasValue
+                    ? config.CacheDuration.Value
+                    : iOSBinding.RoktCacheConfig.MaxCacheDuration;
+                var cacheAttributes = ConvertToNSDictionary<NSString, NSString>(config.CacheAttributes);
+                var cacheConfig = new iOSBinding.RoktCacheConfig(cacheDuration, cacheAttributes);
+                builder = builder.CacheConfig(cacheConfig);
+            }
+
+            return builder.Build();
+        }
+
+        internal static iOSBinding.RoktColorMode ConvertToMpRoktColorMode(RoktColorMode colorMode)
+        {
+            switch (colorMode)
+            {
+                case RoktColorMode.Light:
+                    return iOSBinding.RoktColorMode.Light;
+                case RoktColorMode.Dark:
+                    return iOSBinding.RoktColorMode.Dark;
+                case RoktColorMode.System:
+                default:
+                    return iOSBinding.RoktColorMode.System;
+            }
         }
 
         internal static Action<iOSBinding.RoktEvent> ConvertToMpRoktEventCallback(RoktEventCallback callbacks)

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
@@ -259,6 +259,23 @@ namespace mParticle.MAUI.iOS.Utils
             return ConvertToMpRoktEventCallback(callbacks, null);
         }
 
+        internal static Action<iOSBinding.RoktEvent> ConvertToMpRoktEventCallback(Action<RoktEvent> onEvent)
+        {
+            if (onEvent == null)
+            {
+                return null;
+            }
+
+            return roktEvent =>
+            {
+                var crossPlatformEvent = ConvertToCrossPlatformRoktEvent(roktEvent);
+                if (crossPlatformEvent != null)
+                {
+                    onEvent.Invoke(crossPlatformEvent);
+                }
+            };
+        }
+
         internal static Action<iOSBinding.RoktEvent> ConvertToMpRoktEventCallback(
             RoktEventCallback callbacks, 
             Action<string, double> heightCallback)

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
@@ -313,7 +313,7 @@ namespace mParticle.MAUI.iOS.Utils
                         e.CartItemId,
                         e.CatalogItemId,
                         e.Currency,
-                        e.Description,
+                        e.ItemDescription,
                         e.LinkedProductId,
                         e.ProviderData,
                         ConvertToNullableDecimal(e.Quantity),

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
@@ -254,11 +254,6 @@ namespace mParticle.MAUI.iOS.Utils
             }
         }
 
-        internal static Action<iOSBinding.RoktEvent> ConvertToMpRoktEventCallback(RoktEventCallback callbacks)
-        {
-            return ConvertToMpRoktEventCallback(callbacks, null);
-        }
-
         internal static Action<iOSBinding.RoktEvent> ConvertToMpRoktEventCallback(Action<RoktEvent> onEvent)
         {
             if (onEvent == null)
@@ -272,45 +267,6 @@ namespace mParticle.MAUI.iOS.Utils
                 if (crossPlatformEvent != null)
                 {
                     onEvent.Invoke(crossPlatformEvent);
-                }
-            };
-        }
-
-        internal static Action<iOSBinding.RoktEvent> ConvertToMpRoktEventCallback(
-            RoktEventCallback callbacks, 
-            Action<string, double> heightCallback)
-        {
-            if (callbacks == null && heightCallback == null)
-            {
-                return null;
-            }
-
-            return roktEvent =>
-            {
-                var crossPlatformEvent = ConvertToCrossPlatformRoktEvent(roktEvent);
-                if (crossPlatformEvent != null)
-                {
-                    callbacks?.OnEvent?.Invoke(crossPlatformEvent);
-                }
-
-                switch (roktEvent)
-                {
-                    case iOSBinding.RoktShowLoadingIndicator:
-                        callbacks?.OnShouldShowLoadingIndicator?.Invoke();
-                        break;
-                    case iOSBinding.RoktHideLoadingIndicator:
-                        callbacks?.OnShouldHideLoadingIndicator?.Invoke();
-                        break;
-                    case iOSBinding.RoktPlacementReady:
-                        callbacks?.OnLoad?.Invoke();
-                        break;
-                    case iOSBinding.RoktPlacementClosed closed:
-                        callbacks?.OnUnLoad?.Invoke(closed.Identifier ?? "Unknown");
-                        break;
-                    case iOSBinding.RoktEmbeddedSizeChanged sizeChanged:
-                        callbacks?.OnEmbeddedSizeChange?.Invoke(sizeChanged.Identifier, (float)sizeChanged.UpdatedHeight);
-                        heightCallback?.Invoke(sizeChanged.Identifier, (double)sizeChanged.UpdatedHeight);
-                        break;
                 }
             };
         }

--- a/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
+++ b/Sdk/MParticle.Maui.Sdk/macios/mParticleBinding.MaciOS.Binding/Utils/Utils.cs
@@ -270,6 +270,12 @@ namespace mParticle.MAUI.iOS.Utils
 
             return roktEvent =>
             {
+                var crossPlatformEvent = ConvertToCrossPlatformRoktEvent(roktEvent);
+                if (crossPlatformEvent != null)
+                {
+                    callbacks?.OnEvent?.Invoke(crossPlatformEvent);
+                }
+
                 switch (roktEvent)
                 {
                     case iOSBinding.RoktShowLoadingIndicator:
@@ -290,6 +296,74 @@ namespace mParticle.MAUI.iOS.Utils
                         break;
                 }
             };
+        }
+
+        internal static RoktEvent ConvertToCrossPlatformRoktEvent(iOSBinding.RoktEvent roktEvent)
+        {
+            switch (roktEvent)
+            {
+                case iOSBinding.RoktInitComplete e:
+                    return new RoktInitComplete(e.Success);
+                case iOSBinding.RoktShowLoadingIndicator:
+                    return new RoktShowLoadingIndicator();
+                case iOSBinding.RoktHideLoadingIndicator:
+                    return new RoktHideLoadingIndicator();
+                case iOSBinding.RoktPlacementReady e:
+                    return new RoktPlacementReady(e.Identifier);
+                case iOSBinding.RoktPlacementInteractive e:
+                    return new RoktPlacementInteractive(e.Identifier);
+                case iOSBinding.RoktPlacementClosed e:
+                    return new RoktPlacementClosed(e.Identifier);
+                case iOSBinding.RoktPlacementCompleted e:
+                    return new RoktPlacementCompleted(e.Identifier);
+                case iOSBinding.RoktPlacementFailure e:
+                    return new RoktPlacementFailure(e.Identifier);
+                case iOSBinding.RoktOfferEngagement e:
+                    return new RoktOfferEngagement(e.Identifier);
+                case iOSBinding.RoktPositiveEngagement e:
+                    return new RoktPositiveEngagement(e.Identifier);
+                case iOSBinding.RoktFirstPositiveEngagement e:
+                    return new RoktFirstPositiveEngagement(
+                        e.Identifier,
+                        attributes => e.SetFulfillmentAttributes?.Invoke(ConvertToNSDictionary<NSString, NSString>(attributes)));
+                case iOSBinding.RoktOpenUrl e:
+                    return new RoktOpenUrl(e.Identifier, e.Url);
+                case iOSBinding.RoktEmbeddedSizeChanged e:
+                    return new RoktEmbeddedSizeChanged(e.Identifier, (double)e.UpdatedHeight);
+                case iOSBinding.RoktCartItemInstantPurchaseInitiated e:
+                    return new RoktCartItemInstantPurchaseInitiated(e.Identifier, e.CatalogItemId, e.CartItemId);
+                case iOSBinding.RoktCartItemInstantPurchase e:
+                    return new RoktCartItemInstantPurchase(
+                        e.Identifier,
+                        e.Name,
+                        e.CartItemId,
+                        e.CatalogItemId,
+                        e.Currency,
+                        e.Description,
+                        e.LinkedProductId,
+                        e.ProviderData,
+                        ConvertToNullableDecimal(e.Quantity),
+                        ConvertToNullableDecimal(e.TotalPrice),
+                        ConvertToNullableDecimal(e.UnitPrice));
+                case iOSBinding.RoktCartItemInstantPurchaseFailure e:
+                    return new RoktCartItemInstantPurchaseFailure(e.Identifier, e.CatalogItemId, e.CartItemId, e.Error);
+                case iOSBinding.RoktInstantPurchaseDismissal e:
+                    return new RoktInstantPurchaseDismissal(e.Identifier);
+                case iOSBinding.RoktCartItemDevicePay e:
+                    return new RoktCartItemDevicePay(e.Identifier, e.CatalogItemId, e.CartItemId, e.PaymentProvider);
+                default:
+                    return null;
+            }
+        }
+
+        internal static decimal? ConvertToNullableDecimal(NSDecimalNumber value)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            return value.DecimalValue;
         }
 
         internal static NSDictionary<NSString, NSString> ConvertToNSDictionary<T, V>(Dictionary<string, string> dictionary) where T : NSString where V : NSString

--- a/Sdk/MParticle.Maui.Sdk/macios/native/mParticleBinding/mParticleBinding.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sdk/MParticle.Maui.Sdk/macios/native/mParticleBinding/mParticleBinding.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mParticle/mparticle-apple-sdk",
       "state" : {
-        "revision" : "0bed61c5588bedf5ec120717c3c54b5176c73b29",
-        "version" : "9.0.0"
+        "revision" : "765a405eef554bc36541da08b735575a7924d05d",
+        "version" : "9.1.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ROKT/rokt-contracts-apple.git",
       "state" : {
-        "revision" : "ca2ff1061f5d2fe8d611c7ac17e2af8c931734b0",
-        "version" : "0.1.3"
+        "revision" : "f504822a77a7c7127bac74805e5858a14f25118d",
+        "version" : "2.0.1"
       }
     }
   ],

--- a/Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM/Package.swift
+++ b/Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/mParticle/mparticle-apple-sdk", exact: "9.0.0")
+        .package(url: "https://github.com/mParticle/mparticle-apple-sdk", exact: "9.1.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.103",
-    "rollForward": "latestPatch",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.103",
-    "rollForward": "latestFeature",
+    "rollForward": "latestPatch",
     "allowPrerelease": false
   }
 }


### PR DESCRIPTION
## Background
This updates the MAUI Rokt integration to use a single cross-platform event model and callback shape across iOS and Android. It removes legacy callback APIs and adds Android event subscription support that matches the iOS usage pattern.

## What Has Changed
- Added Android placement event subscription via Kotlin bridge and mapped native `RoktEvent` values into cross-platform `Action<RoktEvent>` callbacks.
- Aligned iOS bindings and cross-platform abstractions with current Rokt contracts, including expanded event hierarchy and config mapping updates.
- Removed legacy `RoktEventCallback` usage from public placement APIs and migrated sample verification flows to the new event subscription pattern.
- Updated Android core dependency and related binding references to the latest integrated mParticle Android SDK version.
- Fixed iOS decimal mapping for Rokt event payloads to restore successful iOS builds.

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
This PR is scoped to mParticle MAUI SDK and related integration app updates only. The remaining two package updates will be submitted in separate follow-up PRs.