### PR TITLE
chore: configure dependabot for native sdk dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,24 +9,6 @@ updates:
       - dependabot
     commit-message:
       prefix: chore
-  - package-ecosystem: gradle
-    directory: /Sdk/MParticle.Maui.Sdk/android/native/MParticleBinding
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 4
-    labels:
-      - dependabot
-    commit-message:
-      prefix: chore
-  - package-ecosystem: gradle
-    directory: /Kits/rokt/Sdk/MParticle.Maui.Rokt/android/native/MParticleRoktBinding
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 4
-    labels:
-      - dependabot
-    commit-message:
-      prefix: chore
   - package-ecosystem: swift
     directory: /Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 4
+    labels:
+      - dependabot
+    commit-message:
+      prefix: chore
+  - package-ecosystem: gradle
+    directory: /Sdk/MParticle.Maui.Sdk/android/native/MParticleBinding
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 4
+    labels:
+      - dependabot
+    commit-message:
+      prefix: chore
+  - package-ecosystem: gradle
+    directory: /Kits/rokt/Sdk/MParticle.Maui.Rokt/android/native/MParticleRoktBinding
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 4
+    labels:
+      - dependabot
+    commit-message:
+      prefix: chore
+  - package-ecosystem: swift
+    directory: /Sdk/MParticle.Maui.Sdk/macios/native/mParticleSPM
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - dependabot
+    commit-message:
+      prefix: chore
+  - package-ecosystem: swift
+    directory: /Kits/rokt/Sdk/MParticle.Maui.Rokt/macios/native/mParticleSPM
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - dependabot
+    commit-message:
+      prefix: chore
+  - package-ecosystem: swift
+    directory: /Kits/rokt/Sdk/MParticle.Maui.Rokt.Payments/macios/native/mParticleRoktPaymentsSPM
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - dependabot
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
## Background
This updates Dependabot coverage to track native dependency sources used by the MAUI bindings.
It keeps Android and Apple native SDK references current without introducing NuGet update noise.

## What Has Changed
- Added Dependabot configuration for Android native Gradle dependency manifests.
- Added Dependabot configuration for Apple native Swift Package manifests.
- Added Dependabot configuration for GitHub Actions workflows.

## Screenshots/Video
N/A

## Checklist
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have tested this locally.

## Additional Notes
Validation sequence was executed successfully (`trunk check`, restore, build, and pack).